### PR TITLE
Fix: topTen 차트 툴팁 구현 및 코호트 색상 매핑 방식 변경

### DIFF
--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -8,6 +8,7 @@
     let width;
     let height;
     export let margin = { top: 30, right: 120, bottom: 50, left: 50 };  // 오른쪽 여백 증가
+    export let cohortColorMap;
 
     $: uniqueSeries = [...new Set(data.map(d => d.series))];
     $: visibleSeries = new Set(uniqueSeries);
@@ -83,9 +84,7 @@
             .domain([0, d3.max(data, d => d.value)])
             .nice()
             .range([height - margin.bottom, margin.top]);
-    
-        const color = d3.scaleOrdinal(d3.schemeCategory10);
-  
+      
         // X축 & Y축
         const xAxis = d3.axisBottom(x);
         const yAxis = d3.axisLeft(y);
@@ -97,7 +96,8 @@
             .style("text-anchor", "end")
             .attr("dx", "-.8em")
             .attr("dy", ".15em")
-            .attr("transform", "rotate(-45)");
+            .attr("transform", "rotate(-45)")
+            .attr("stroke", d => cohortColorMap[d]); 
     
         svg.append("g")
             .attr("transform", `translate(${margin.left},0)`)
@@ -119,9 +119,9 @@
             .append("path")
             .datum(values)
             .attr("fill", "none")
-            .attr("stroke", color(key))
             .attr("stroke-width", 2)
-            .attr("d", line)
+            .attr("stroke", cohortColorMap[key])
+            .attr("d", line(values))
             .attr("class", `line-${key}`)
             .attr("opacity", visibleSeries.has(key) ? 1 : 0);
   
@@ -134,7 +134,7 @@
             .attr("cx", d => x(d.label) + x.bandwidth() / 2)
             .attr("cy", d => y(d.value))
             .attr("r", 4)
-            .attr("fill", color(key))
+            .attr("fill", cohortColorMap[key])
             .attr("stroke", "white")
             .attr("opacity", visibleSeries.has(key) ? 1 : 0)
             .on("mouseover", function (event, d) {
@@ -164,8 +164,8 @@
           .attr("x", 0)
           .attr("width", 12)
           .attr("height", 12)
-          .attr("fill", d => color(d[0]))
-          .attr("stroke", d => color(d[0]))
+          .attr("fill", d => cohortColorMap[d[0]])
+          .attr("stroke", d => cohortColorMap[d[0]])
           .attr("cursor", "pointer")
           .on("click", (event, d) => toggleSeries(d[0]));
   

--- a/src/lib/components/LineChart.svelte
+++ b/src/lib/components/LineChart.svelte
@@ -142,7 +142,15 @@
                 .style("display", "block")
                 .style("left", (event.pageX + 10) + "px")
                 .style("top", (event.pageY - 10) + "px")
-                .html(`Cohort: ${d.series}<br>Age: ${d.label}<br>Value: ${d.value}`);
+                .html(`
+                    <div class="p-1">
+                    <div class="text-[10px] font-semibold mb-0.5">${d.series}</div>
+                    <div class="text-[9px] text-gray-600">
+                        ${d.label}:
+                        <span class="ml-0.5 font-medium text-black">${d.value.toLocaleString()}</span>
+                    </div>
+                    </div>
+                `);
             })
             .on("mouseout", function () {
                 tooltip.style("display", "none");
@@ -193,13 +201,14 @@
         .append("div")
         .style("position", "absolute")
         .style("background", "white")
-        .style("border", "1px solid #ccc")
-        .style("padding", "5px")
-        .style("border-radius", "5px")
+        .style("border", "1px solid #eee")
+        .style("border-radius", "4px")
+        .style("padding", "0")
         .style("display", "none")
         .style("pointer-events", "none")
-        .style("font-size", "12px")
-        .style("z-index", "100");
+        .style("z-index", "100")
+        .style("box-shadow", "0 2px 4px rgba(0,0,0,0.05)")
+        .style("backdrop-filter", "blur-sm");
     }
   
   </script>

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -187,10 +187,17 @@
       tooltipY = event.clientY - containerRect.top;
       
       tooltipContent = `
-        <div class="p-2">
-          <div class="font-bold">${d.data[domainKey]}</div>
-          <div>${cohort}: ${value.toLocaleString()}</div>
-        </div>
+        <div class="p-1">
+            <div class="text-[10px] font-semibold mb-0.5">${d.data[domainKey]}</div>
+            <div class="text-[9px] text-gray-600">
+              ${currentCohort}:
+              <span class="ml-0.5 font-medium">${value.toLocaleString()}</span>
+              </br>
+              <span class="text-gray-400 ml-0.5">
+                (${value}/${total} ${percentage}%)
+              </span>
+            </div>
+          </div>
       `;
 
       tooltipVisible = true;
@@ -240,9 +247,8 @@
 
   <!-- 툴팁 -->
   {#if tooltipVisible}
-    <div 
-      class="absolute bg-white shadow-lg rounded-md border border-gray-200 z-50 pointer-events-none transition-all duration-100"
-      style="left: {tooltipX}px; top: {tooltipY}px;"
+    <div class="absolute bg-white/95 shadow-sm rounded-md border border-gray-100 z-50 pointer-events-none transition-all duration-75 backdrop-blur-sm"
+    style="left: {tooltipX}px; top: {tooltipY}px;"
     >
       {@html tooltipContent}
     </div>

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -1,6 +1,6 @@
 <script>
   import * as d3 from "d3";
-  import { onMount, onDestroy } from "svelte";
+  import { onMount, onDestroy, tick } from "svelte";
   import { browser } from "$app/environment";
   import { fade } from 'svelte/transition';
 
@@ -25,6 +25,7 @@
   let tooltipX = 0;
   let tooltipY = 0;
   let tooltipContent = '';
+  let tooltipElement;
 
   let orderedCohorts;
 
@@ -182,10 +183,16 @@
 
       const rect = this.getBoundingClientRect();
       const containerRect = chartContainer.getBoundingClientRect();
+      const tooltipHeight = tooltipElement?.offsetHeight || 40;
+      const spaceBelow = containerRect.bottom - event.clientY;
 
       tooltipX = rect.right - containerRect.left;
-      tooltipY = event.clientY - containerRect.top;
-      
+        if(spaceBelow < tooltipHeight){
+            tooltipY = event.clientY - containerRect.top - tooltipHeight;
+        }else{
+          tooltipY = event.clientY - containerRect.top;
+        }
+
       tooltipContent = `
         <div class="p-1">
             <div class="text-[10px] font-semibold mb-0.5">${d.data[domainKey]}</div>
@@ -206,12 +213,21 @@
         .style("stroke", "#666")
         .style("stroke-width", "2px");
     })
-    .on("mousemove", function(event) {
+    .on("mousemove", async function(event) {
       const rect = this.getBoundingClientRect();
       const containerRect = chartContainer.getBoundingClientRect();
 
+      const tooltipHeight = tooltipElement?.offsetHeight || 40;
+      const spaceBelow = containerRect.bottom - event.clientY;
+
       tooltipX = rect.right - containerRect.left;
-      tooltipY = event.clientY - containerRect.top;
+
+        if(spaceBelow < tooltipHeight){
+            tooltipY = event.clientY - containerRect.top - tooltipHeight;
+        }else{
+          tooltipY = event.clientY - containerRect.top;
+        }
+      
     })
     .on("mouseout", function() {
       tooltipVisible = false;
@@ -247,7 +263,8 @@
 
   <!-- 툴팁 -->
   {#if tooltipVisible}
-    <div class="absolute bg-white/95 shadow-sm rounded-md border border-gray-100 z-50 pointer-events-none transition-all duration-75 backdrop-blur-sm"
+    <div bind:this={tooltipElement}
+    class="absolute bg-white/95 shadow-sm rounded-md border border-gray-100 z-50 pointer-events-none transition-all duration-75 backdrop-blur-sm"
     style="left: {tooltipX}px; top: {tooltipY}px;"
     >
       {@html tooltipContent}

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -8,6 +8,7 @@
   export let data = [];
   export let domainKey; // 도메인 키 (condition, drug, procedure, measurement)
   export let viewType = 'combined';
+  export let cohortTotalCounts = {};
     
   // drawChart 함수 인자
   let transformedData;
@@ -176,6 +177,8 @@
     .on("mouseover", function(event, d) {
       const cohort = d3.select(this.parentNode).datum().key;
       const value = d[1] - d[0];
+      const total = cohortTotalCounts[currentCohort];
+      const percentage = ((value / total) * 100).toFixed(2);
 
       const rect = this.getBoundingClientRect();
       const containerRect = chartContainer.getBoundingClientRect();

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -177,9 +177,12 @@
       const cohort = d3.select(this.parentNode).datum().key;
       const value = d[1] - d[0];
 
-      tooltipVisible = true;
-      tooltipX = event.pageX;
-      tooltipY = event.pageY;
+      const rect = this.getBoundingClientRect();
+      const containerRect = chartContainer.getBoundingClientRect();
+
+      tooltipX = rect.right - containerRect.left;
+      tooltipY = event.clientY - containerRect.top;
+      
       tooltipContent = `
         <div class="p-2">
           <div class="font-bold">${d.data[domainKey]}</div>
@@ -187,14 +190,18 @@
         </div>
       `;
 
+      tooltipVisible = true;
       d3.select(this)
         .attr("opacity", 1)
         .style("stroke", "#666")
         .style("stroke-width", "2px");
     })
     .on("mousemove", function(event) {
-      tooltipX = event.pageX - 150;
-      tooltipY = event.pageY - 320;
+      const rect = this.getBoundingClientRect();
+      const containerRect = chartContainer.getBoundingClientRect();
+
+      tooltipX = rect.right - containerRect.left;
+      tooltipY = event.clientY - containerRect.top;
     })
     .on("mouseout", function() {
       tooltipVisible = false;
@@ -225,10 +232,8 @@
 
 </script>
 
-<div class="w-full h-full">
-  <div class="relative w-full h-full">
-    <div bind:this={chartContainer} class="w-full h-full"></div>
-  </div>
+<div class="relative w-full h-full">
+  <div bind:this={chartContainer} class="w-full h-full"></div>
 
   <!-- 툴팁 -->
   {#if tooltipVisible}

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -19,7 +19,7 @@
 	let chartContainer;
 	let width;
 	let height;
-  const margin = { top: 30, right: 80, bottom: 10, left: 120 };
+  const margin = { top: 30, right: 80, bottom: 10, left: 140 };
 
   // 툴팁 상태 관리를 위한 변수들
   let tooltipVisible = false;

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -9,6 +9,7 @@
   export let domainKey; // 도메인 키 (condition, drug, procedure, measurement)
   export let viewType = 'combined';
   export let cohortTotalCounts = {};
+  export let cohortColorMap = {};
     
   // drawChart 함수 인자
   let transformedData;
@@ -135,11 +136,6 @@
       .range([0, height - margin.bottom - margin.top])
       .padding(0.4);
 
-    // 색상 스케일
-    const colorScale = d3.scaleOrdinal()
-      .domain(orderedCohorts)
-      .range(d3.schemeCategory10);
-
     // SVG 생성
     const svg = d3.select(chartContainer)
       .append("svg")
@@ -165,8 +161,7 @@
       .selectAll("g")
       .data(series)
       .join("g")
-      .attr("fill", (d, i) => colorScale(cohorts[i]));
-      .attr("fill", (d, i) => colorScale(orderedCohorts[i]));
+      .attr("fill", (d, i) => cohortColorMap[orderedCohorts[i]]);
 
     groups.selectAll("rect")
     .data(d => d)
@@ -176,7 +171,7 @@
     .attr("width", d => xScale(d[1]) - xScale(d[0]))
     .attr("height", yScale.bandwidth())
     .on("mouseover", function(event, d) {
-      const cohort = d3.select(this.parentNode).datum().key;
+      const currentCohort = d3.select(this.parentNode).datum().key;
       const value = d[1] - d[0];
       const total = cohortTotalCounts[currentCohort];
       const percentage = ((value / total) * 100).toFixed(2);

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -204,7 +204,6 @@
 
       tooltipVisible = true;
       d3.select(this)
-        .attr("opacity", 1)
         .style("stroke", "#666")
         .style("stroke-width", "2px");
     })
@@ -222,12 +221,10 @@
         }else{
           tooltipY = event.clientY - containerRect.top;
         }
-      
     })
     .on("mouseout", function() {
       tooltipVisible = false;
       d3.select(this)
-        .attr("opacity", 1)
         .style("stroke", "none")
     });
   }

--- a/src/lib/components/StackedBarChart_horizontal.svelte
+++ b/src/lib/components/StackedBarChart_horizontal.svelte
@@ -18,7 +18,7 @@
 	let chartContainer;
 	let width;
 	let height;
-  const margin = { top: 30, right: 150, bottom: 10, left: 120 };
+  const margin = { top: 30, right: 80, bottom: 10, left: 120 };
 
   // 툴팁 상태 관리를 위한 변수들
   let tooltipVisible = false;
@@ -235,25 +235,6 @@
         .attr("opacity", 1)
         .style("stroke", "none")
     });
-
-    // 범례 추가
-    const legend = svg.append("g")
-      .attr("transform", `translate(${width - margin.right + 10}, ${margin.top})`)
-      .selectAll("g")
-      .data(orderedCohorts)
-      .join("g")
-      .attr("transform", (d, i) => `translate(0, ${i * 20})`);
-
-    legend.append("rect")
-      .attr("width", 15)
-      .attr("height", 15)
-      .attr("fill", d => colorScale(d));
-
-    legend.append("text")
-      .attr("x", 20)
-      .attr("y", 12)
-      .text(d => d)
-      .style("font-size", "12px");
   }
 
 </script>

--- a/src/routes/cohort/comparison/+page.svelte
+++ b/src/routes/cohort/comparison/+page.svelte
@@ -521,9 +521,9 @@
           {#if selectItems[0].checked}
             <ChartCard 
               title="Gender Ratio" 
-              description="Comparison of gender distribution across selected cohorts"
+              description="The ratio of genders within the cohort."
               chartId={0}
-              type="full",
+              type="full"
               on:close={handleChartClose}
             >
               <div class="w-full h-full flex flex-col">
@@ -537,7 +537,7 @@
           {#if selectItems[1].checked}
             <ChartCard 
               title="Mortality" 
-              description="Comparison of mortality across selected cohorts"
+              description="The percentage of patients within the cohort who have died."
               chartId={1}
               type="full"
               on:close={handleChartClose}
@@ -555,7 +555,7 @@
           {#if selectItems[2].checked}
             <ChartCard 
               title="Visit Type Ratio"
-              description="Comparison of visit types across selected cohorts"
+              description="The proportion of different types of medical visits (outpatient, inpatient, emergency room, etc.) that occurred during the cohort period."
               chartId={2}
               type="full"
               on:close={handleChartClose}
@@ -573,7 +573,7 @@
           {#if selectItems[3].checked}
             <ChartCard 
               title="Distribution of First Occurrence Age"
-              description="Age distribution analysis"
+              description="The age distribution of patients at the time of their first medical visit during the cohort period."
               chartId={3}
               type="full"
               on:close={handleChartClose}
@@ -592,7 +592,7 @@
           {#if selectItems[4].checked}
           <ChartCard 
             title="Distribution of Visit Count"
-            description="Visit frequency analysis"
+            description="The distribution of the total number of medical visits made by patients during the cohort period."
             chartId={4}
             type="full"
             on:close={handleChartClose}
@@ -613,7 +613,7 @@
           {#if selectItems[5].checked}
             <ChartCard 
               title="Top 10 Drugs"
-              description="Most frequently prescribed medications"
+              description="The list of the top 10 most frequently prescribed medications for patients in the cohort."
               chartId={5}
               type="half"
               showSelector={true}
@@ -646,7 +646,7 @@
           {#if selectItems[6].checked}
               <ChartCard 
                 title="Top 10 Conditions"
-                description="Most frequent conditions"
+                description="The list of the top 10 most frequently diagnosed medical conditions among patients in the cohort."
                 chartId={6}
                 type="half"
                 showSelector={true}
@@ -679,7 +679,7 @@
           {#if selectItems[7].checked}
             <ChartCard 
               title="Top 10 Procedures"
-              description="Most frequent procedures"
+              description="The list of the top 10 most frequently performed procedures and medical tests on patients in the cohort."
               chartId={7}
               type="half"
               showSelector={true}
@@ -711,7 +711,7 @@
           {#if selectItems[8].checked}
             <ChartCard 
               title="Top 10 Measurements"
-              description="Most frequent measurements"
+              description="The list of the top 10 most frequently recorded clinical measurements within the cohort."
               chartId={8}
               type="half"
               showSelector={true}

--- a/src/routes/cohort/comparison/+page.svelte
+++ b/src/routes/cohort/comparison/+page.svelte
@@ -43,7 +43,6 @@
   let visitTypeChartData = [];
   let ageDistributionChartData = [];
   let visitCountChartData = [];
-  let topTenDrugsData = [];
   let stackedDrugsData = [];
   let stackedConditionsData = [];
   let stackedMeasurementsData = [];
@@ -120,7 +119,6 @@
         visitTypeChartData = await loadVisitTypeData();
         ageDistributionChartData = await loadAgeDistributionData();
         visitCountChartData = await loadVisitCountData();
-        topTenDrugsData = await loadTopTenDrugsData();
 
         // 각 차트별로 초기 코호트 선택 설정
         Object.keys(selectedCohortStates).forEach(chartType => {
@@ -281,47 +279,6 @@
   } catch (error) {
       console.error('Error loading visit count data:', error);
       return [];
-    }
-  }
-
-  async function loadTopTenDrugsData() {
-    try {
-      return selectedCohorts.map((cohortId) => ({
-        cohortName: cohortStats[cohortId].basicInfo.name,
-        drugs: Object.entries(cohortStats[cohortId].statistics.topTenDrugs)
-          .map(([name, count], index) => ({
-            rank: index + 1,
-            name,
-            count
-          }))
-      }));
-    } catch (error) {
-      console.error('Error loading top drugs data:', error);
-      return [];
-    }
-  }
-
-  function handleCohortChange(chartType, event) {
-    selectedCohortStates[chartType] = event.target.value;
-  }
-
-  function handleCohortSelect(event) {
-    const { chartId, optionId } = event.detail;
-    
-    // chartId에 따라 적절한 상태 업데이트
-    switch (chartId) {
-      case 6:  // Top 10 Drugs
-        selectedCohortStates.drugs = optionId;
-        break;
-      case 7:  // Top 10 Conditions
-        selectedCohortStates.conditions = optionId;
-        break;
-      case 8:  // Top 10 Procedures
-        selectedCohortStates.procedures = optionId;
-        break;
-      case 9:  // Top 10 Measurements
-        selectedCohortStates.measurements = optionId;
-        break;
     }
   }
 

--- a/src/routes/cohort/comparison/+page.svelte
+++ b/src/routes/cohort/comparison/+page.svelte
@@ -623,7 +623,10 @@
               >
             <div class="w-full h-full flex flex-col">
             <div class="mt-4 flex-grow flex items-center justify-center">
-                <LineChart data={ageDistributionChartData} />
+                <LineChart 
+                  data={ageDistributionChartData}
+                  cohortColorMap={cohortColorMap}
+                />
               </div>
             </div>
           </ChartCard>
@@ -640,7 +643,10 @@
             <div class="w-full h-full flex flex-col">
               <div class="mt-4 flex-grow flex items-center justify-center">
                 {#if visitCountChartData && visitCountChartData.length > 0}
-                  <LineChart data={visitCountChartData} />
+                  <LineChart
+                    data={visitCountChartData}
+                    cohortColorMap={cohortColorMap}
+                  />
                 {/if}
               </div>
             </div>

--- a/src/routes/cohort/comparison/+page.svelte
+++ b/src/routes/cohort/comparison/+page.svelte
@@ -648,6 +648,12 @@
                     data={stackedDrugsData}
                     domainKey="drug"
                     viewType={topTenDrugViewType}
+                    cohortTotalCounts = {Object.fromEntries(
+                      selectedCohorts.map(cohortId => [
+                        cohortStats[cohortId].basicInfo.name,
+                        cohortStats[cohortId].totalPatients
+                      ])
+                    )}
                   />
                 </div>
                 {/if}
@@ -674,6 +680,12 @@
                       data={stackedConditionsData}
                       domainKey="condition"
                       viewType={topTenConditionViewType}
+                      cohortTotalCounts = {Object.fromEntries(
+                      selectedCohorts.map(cohortId => [
+                        cohortStats[cohortId].basicInfo.name,
+                        cohortStats[cohortId].totalPatients
+                      ])
+                    )}
                     />
                   </div>
                   {/if}
@@ -700,6 +712,12 @@
                     data={stackedProceduresData}
                     domainKey="procedure"
                     viewType={topTenProcedureViewType}
+                    cohortTotalCounts = {Object.fromEntries(
+                      selectedCohorts.map(cohortId => [
+                        cohortStats[cohortId].basicInfo.name,
+                        cohortStats[cohortId].totalPatients
+                      ])
+                    )}
                   />
                 </div>
               {/if}
@@ -725,6 +743,12 @@
                     data={stackedMeasurementsData}
                     domainKey="measurement"
                     viewType={topTenMeasurementViewType}
+                    cohortTotalCounts = {Object.fromEntries(
+                      selectedCohorts.map(cohortId => [
+                        cohortStats[cohortId].basicInfo.name,
+                        cohortStats[cohortId].totalPatients
+                      ])
+                    )}
                   />
                 </div>
                 {/if}

--- a/src/routes/cohort/comparison/+page.svelte
+++ b/src/routes/cohort/comparison/+page.svelte
@@ -87,6 +87,16 @@
     {key: 'count', label: 'Count'}
   ]
 
+  const COHORT_COLORS = [
+    "#2977b7",
+    "#eda946",
+    "#d45836",
+    "#fac2ad",
+    "#77722e",
+  ]
+
+  let cohortColorMap = {};
+
   onMount(async () => {
     const cohortIds = $page.url.searchParams.get('cohorts')?.split(',') || [];
     selectedCohorts = cohortIds;
@@ -97,6 +107,14 @@
       console.log('load cohortData', cohortData);
 
       if (selectedCohorts.length > 0) {
+        // 코호트별 색상 매핑 초기화
+        cohortColorMap = Object.fromEntries(
+          selectedCohorts.map((cohortId, index) => [
+            cohortStats[cohortId].basicInfo.name,
+            COHORT_COLORS[index % COHORT_COLORS.length]
+          ])
+        );
+
         genderChartData = await loadGenderData();
         mortalityChartData = await loadMortalityData();
         visitTypeChartData = await loadVisitTypeData();
@@ -648,6 +666,7 @@
                     data={stackedDrugsData}
                     domainKey="drug"
                     viewType={topTenDrugViewType}
+                    cohortColorMap={cohortColorMap}
                     cohortTotalCounts = {Object.fromEntries(
                       selectedCohorts.map(cohortId => [
                         cohortStats[cohortId].basicInfo.name,
@@ -680,6 +699,7 @@
                       data={stackedConditionsData}
                       domainKey="condition"
                       viewType={topTenConditionViewType}
+                      cohortColorMap={cohortColorMap}
                       cohortTotalCounts = {Object.fromEntries(
                       selectedCohorts.map(cohortId => [
                         cohortStats[cohortId].basicInfo.name,
@@ -712,6 +732,7 @@
                     data={stackedProceduresData}
                     domainKey="procedure"
                     viewType={topTenProcedureViewType}
+                    cohortColorMap={cohortColorMap}
                     cohortTotalCounts = {Object.fromEntries(
                       selectedCohorts.map(cohortId => [
                         cohortStats[cohortId].basicInfo.name,
@@ -743,6 +764,7 @@
                     data={stackedMeasurementsData}
                     domainKey="measurement"
                     viewType={topTenMeasurementViewType}
+                    cohortColorMap={cohortColorMap}
                     cohortTotalCounts = {Object.fromEntries(
                       selectedCohorts.map(cohortId => [
                         cohortStats[cohortId].basicInfo.name,

--- a/src/routes/cohort/comparison/+page.svelte
+++ b/src/routes/cohort/comparison/+page.svelte
@@ -623,7 +623,7 @@
               on:close={handleChartClose}
             >
               <div class="w-full h-full flex flex-col p-4">
-                {#if topTenDrugsData.length > 0}
+                {#if stackedDrugsData.length > 0}
                 <div class="flex-1 overflow-x-auto overflow-y-auto">
                   <StackedBarChartHorizontal
                     data={stackedDrugsData}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#6,  #7, #8

## 📝 작업 내용

1. Top 10 Series 툴팁이 나오지 않는 문제 해결
 css positioning이 chartContainer를 기준으로 하여 툴팁이 올바른 위치가 아닌 화면 밖 영역에 표시되는 문제였습니다. 상대적인 위치 계산을 추가하여 해결했습니다. 

2. Top 10 Series 비율 고려한 호버 텍스트 추가
코호트 내 환자 수 대비 해당 label 환자수를 알 수 있도록 하기 위해 비율을 툴팁에 추가하였습니다. 

3. 코호트 간 비교 페이지의 코호트 색상 매핑 방식 변경
orderedCohorts로 변환된 상태에서 색상 매핑이 다시 이루어지고 있어 anchor 코호트가 변경될 때마다 색상이 달라지는 문제가 발생했습니다. 각 컴포넌트에서 코호트의 색상이 다르게 적용되면 사용자 입장에서 혼란을 줄 수 있으므로, 코호트마다 일관된 색상을 유지하도록 수정하였습니다. 코호트 색상 매핑은 comparison의 `+page.svelte`에서 정의되고, 각 차트 컴포넌트로 전달하여 동일하게 사용됩니다.

### 스크린샷

<img width="563" alt="image" src="https://github.com/user-attachments/assets/533365f6-7e2a-42e8-85d4-e55bb354305b" />
<img width="545" alt="image" src="https://github.com/user-attachments/assets/fb2d786b-cb77-4dc6-82d6-7df6292be90b" />

위 스크린샷을 통해 </br>1. 툴팁의 작동 </br>2. 코호트 환자 수 대비 해당 Label 환자수의 비율 표시 </br>3. top 10 view가 달라져도 코호트의 색상 매핑이 변하지 않는 것</br>을 확인할 수 있습니다. 

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
