### PR TITLE
Feat: CDM 타임라인 Death 및 디자인 변경

### DIFF
--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -69,11 +69,11 @@
     };
 
     const visitMapping = {
-        9201: [0, "Inpatient", "#FF0000"],
-        9202: [1, "Outpatient", "#FF7F00"],
-        9203: [2, "Emergency Room Visit", "#FFFF00"],
-        581477: [3, "Home Visit", "#00FF00"],
-        44818517: [4, "Other Visit Type", "#0000FF"]
+        9201: [0, "Inpatient", "#FF6B6B"],
+        9202: [1, "Outpatient", "#4ECDC4"],
+        9203: [2, "Emergency Room Visit", "#FFB236"],
+        581477: [3, "Home Visit", "#95A5A6"],
+        44818517: [4, "Other Visit Type", "#BDC3C7"]
     };
 
     async function fetchDataById(id) {

--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -328,10 +328,18 @@
         svg.call(zoom); // ✅ SVG에 zoom 기능 적용
     }
 
-    // ✅ 화면 크기 변경 감지 → 타임라인 다시 그리기
     onMount(() => {
         drawTimeline();
-        window.addEventListener("resize", drawTimeline);
+
+        const handleResize = () => {
+            // 기존 svg 강제 삭제 후 다시 그리기
+            const svg = d3.select(timelineContainer).select("svg");
+            svg.remove();
+            drawTimeline();
+        };
+
+        window.addEventListener("resize", handleResize);
+        onDestroy(() => window.removeEventListener("resize", handleResize));
     });
 
     // ✅ 데이터 변경 시마다 실행
@@ -376,22 +384,10 @@
         </div>
     </div>
     <!-- 🔹 타임라인을 렌더링할 컨테이너 -->
-    <div class="w-full h-[200px]" bind:this={timelineContainer}></div>
+    <div class="w-full h-[200px] min-w-[850px]" bind:this={timelineContainer}></div>
 </header>
 <div class="pt-8 pb-[60px] flex flex-col">
     {#if !isStatisticsView}
-        <!-- <button 
-            class="ml-auto mb-8 w-fit px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 transition-all duration-200 ease-in-out"
-                on:click={() => {
-                    if(Object.keys(tableProps).length === 0){
-                        notify();
-                    }
-                    else{
-                        showModal = true
-                    }
-            }}>
-            Select Tables
-        </button> -->
         <div class="w-full">
             <div class="grid grid-cols-2 gap-4">
                 <ChartCard
@@ -525,9 +521,19 @@
                 </ChartCard>
             </div>
         </div>
-
-
-
+    {:else}
+        <button 
+            class="ml-auto mb-8 w-fit px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg shadow-md hover:bg-blue-700 transition-all duration-200 ease-in-out"
+                on:click={() => {
+                    if(Object.keys(tableProps).length === 0){
+                        notify();
+                    }
+                    else{
+                        showModal = true
+                    }
+            }}>
+            Select Tables
+        </button>
         {#if tableProps?.cdm_info}
             <CDMInfo careSite={tableProps["cdm_info"].careSite} location={tableProps["cdm_info"].location} visitOccurrence={tableProps["cdm_info"].visitOccurrence} />
             <svelte:component this={tableComponents[tableId]} {...tableProps[tableId]} />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#48 

## 📝 작업 내용
timeline Bar의 Visiti Concept 별 색상을 변경했습니다.
각 Person 별로 Death 테이블의 유무의 따른 Death Bar를 구현했습니다. Death Bar는 Tooltip을 통해 death 정보를 보여줍니다.

타임라인 크기가 안커지던 버그를 수정했습니다.
Select Tables가 Viewer에서 안보이던 버그를 수정했습니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/da71de05-1bb1-4d83-addd-3cb79425e1db)

![image](https://github.com/user-attachments/assets/98130527-168d-4a8b-92cc-2502520c76e7)

## 💬 리뷰 요구사항(선택)
drawTimeline 함수가 볼륨이 너무 커서 기능별로 나눠서 리팩터링했는데 괜찮은지 중점으로 체크해주시고, UI가 변경되면서 오류들이 조금 생겨서 수정했습니다. 그 부분도 확인 부탁드려요.


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
