### PR TITLE
Feat: 단일 CDM 뷰어 테이블 수정

### DIFF
--- a/frontend/src/lib/components/Modal.svelte
+++ b/frontend/src/lib/components/Modal.svelte
@@ -88,7 +88,7 @@
           {#each tables as table}
             <label>
               <input type="checkbox" value={table.id} checked={selectedTables.has(table.id)} on:change={() => toggleTable(table.id)} />
-              {table.name}
+                {table.name}
             </label>
           {/each}
         </div>

--- a/frontend/src/lib/components/Table/BioSignal.svelte
+++ b/frontend/src/lib/components/Table/BioSignal.svelte
@@ -12,8 +12,6 @@
 
   {#each bioSignal as signal}
     <div class="bio-signal-row">
-      <span class="info"><strong>Bio Signal ID:</strong> {signal["bio_signal)id"]}</span>
-      <span class="divider">|</span>
       <span class="info"><strong>Date:</strong> {signal.bio_signal_date}</span>
       <span class="divider">|</span>
       <span class="info"><strong>Concept ID:</strong> 
@@ -42,7 +40,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }

--- a/frontend/src/lib/components/Table/CDMInfo.svelte
+++ b/frontend/src/lib/components/Table/CDMInfo.svelte
@@ -6,20 +6,17 @@
 
 <div class="visit-container">
   <h2 class="title">Visit & Care Site Information</h2>
-
-  {#each visitOccurrence as visit}
-    <div class="visit-row">
-      <div class="visit-info">
-        <span class="info"><strong>Visit ID:</strong> {visit.visit_occurrence_id}</span>
-        <span class="info"><strong>Visit Dates:</strong> {visit.visit_start_date} ~ {visit.visit_end_date}</span>
-        <span class="info"><strong>Concept ID:</strong> {visit.visit_concept_id}</span>
-      </div>
-      <div class="care-info">
-        <span class="info"><strong>Care Site:</strong> <span class="highlight">{careSite[0].care_site_name}</span> (ID: {careSite[0].care_site_id})</span>
-        <span class="info"><strong>Address:</strong> {location[0].address_1}, {location[0].address_2} / {location[0].zip}</span>
-      </div>
+  <div class="visit-row">
+    <div class="visit-info">
+      <span class="info"><strong>Visit ID:</strong> {visitOccurrence[0].visit_occurrence_id}</span>
+      <span class="info"><strong>Visit Dates:</strong> {visitOccurrence[0].visit_start_date} ~ {visitOccurrence[0].visit_end_date}</span>
+      <span class="info"><strong>Concept ID:</strong> {visitOccurrence[0].visit_concept_id}</span>
     </div>
-  {/each}
+    <div class="care-info">
+      <span class="info"><strong>Care Site:</strong> <span class="highlight">{careSite[0].care_site_name}</span> (ID: {careSite[0].care_site_id})</span>
+      <span class="info"><strong>Address:</strong> {location[0].address_1}, {location[0].address_2} / {location[0].zip}</span>
+    </div>
+  </div>
 </div>
 
 

--- a/frontend/src/lib/components/Table/CDMInfo.svelte
+++ b/frontend/src/lib/components/Table/CDMInfo.svelte
@@ -30,7 +30,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
     text-align: center;

--- a/frontend/src/lib/components/Table/Condition.svelte
+++ b/frontend/src/lib/components/Table/Condition.svelte
@@ -14,8 +14,6 @@
       <span class="divider">|</span>
       <span class="info"><strong>Diagnosis Date:</strong> {cond.condition_start_date} ~ {cond.condition_end_date}</span>
       <span class="divider">|</span>
-      <span class="info"><strong>Visit ID:</strong> {cond.visit_occurrence_id}</span>
-      <span class="divider">|</span>
       <span class="info"><strong>Condition Status:</strong> {cond.condition_status_source_value}</span>
     </div>
   {/each}
@@ -26,7 +24,7 @@
       <span class="divider">|</span>
       <span class="info"><strong>Era Duration:</strong> {era.condition_era_start_date} ~ {era.condition_era_end_date}</span>
       <span class="divider">|</span>
-      <span class="info"><strong>Occurrence Count:</strong> {era.condition_occurrence_count}회</span>
+      <span class="info"><strong>Occurrence Count:</strong> {era.condition_occurrence_count} times</span>
     </div>
   {/each}
 </div>
@@ -41,7 +39,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }
@@ -63,7 +61,7 @@
 
   .info {
     font-weight: normal;
-    font-size: 1.1rem;
+    font-size: 1.0rem;
     margin-right: 10px;
   }
 

--- a/frontend/src/lib/components/Table/Drug.svelte
+++ b/frontend/src/lib/components/Table/Drug.svelte
@@ -68,7 +68,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }

--- a/frontend/src/lib/components/Table/Drug.svelte
+++ b/frontend/src/lib/components/Table/Drug.svelte
@@ -1,16 +1,12 @@
 <script>
-  export let drugEra;
   export let drugExposure;
-  export let drugStrength;
 </script>
 
 <div class="drug-container">
   <h2 class="title">Drug Information</h2>
 
-  <span class="info"><strong>Domain:</strong> {drugStrength[0].drug_concept_id}</span>
-
   <!-- Drug Era (약물 복용 기록) -->
-  {#each drugEra as era}
+  <!-- {#each drugEra as era}
     <div class="drug-row">
       <span class="info"><strong>Drug Era ID:</strong> {era.drug_era_id}</span>
       <span class="divider">|</span>
@@ -20,33 +16,46 @@
       <span class="divider">|</span>
       <span class="info"><strong>Gap Days:</strong> {era.gap_days}일</span>
     </div>
-  {/each}
+  {/each} -->
 
   <!-- Drug Exposure (약물 투여 기록) -->
-  {#each drugExposure as exposure}
-    <div class="drug-row exposure">
-      <span class="info"><strong>Drug Exposure ID:</strong> {exposure.drug_exposure_id}</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Exposure Period:</strong> {exposure.drug_exposure_start_date} ~ {exposure.drug_exposure_end_date}</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Quantity:</strong> {exposure.quantity}</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Days Supply:</strong> {exposure.days_supply}일</span>
-    </div>
-  {/each}
+  {#if drugExposure && drugExposure.length > 0}
+    <table class="drug-table w-full border border-gray-200 text-sm text-left">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="px-4 py-2 border-b">Drug Exposure ID</th>
+          <th class="px-4 py-2 border-b">Exposure Period</th>
+          <th class="px-4 py-2 border-b">Quantity</th>
+          <th class="px-4 py-2 border-b">Days Supply</th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each drugExposure as exposure}
+          <tr class="hover:bg-gray-50">
+            <td class="px-4 py-2 border-b">{exposure.drug_exposure_id}</td>
+            <td class="px-4 py-2 border-b">
+              {exposure.drug_exposure_start_date} ~ {exposure.drug_exposure_end_date}
+            </td>
+            <td class="px-4 py-2 border-b">{exposure.quantity}</td>
+            <td class="px-4 py-2 border-b">{exposure.days_supply} days</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {:else}
+    <p class="text-gray-500 text-sm">No drug exposure data available.</p>
+  {/if}
 
   <!-- Drug Strength (약물 성분 및 용량) -->
-  {#each drugStrength as strength}
+  <!-- {#each drugStrength as strength}
     <div class="drug-row strength">
-      <!-- <span class="info"><strong>Drug Concept ID:</strong> {strength.drug_concept_id}</span> -->
-      <!-- <span class="divider">|</span> -->
       <span class="info"><strong>Ingredient ID:</strong> {strength.ingredient_concept_id}</span>
       <span class="divider">|</span>
       <span class="info"><strong>Total Amount:</strong> {strength.amount_value} mg</span>
       <span class="divider">|</span>
       <span class="info"><strong>Concentration:</strong> {strength.numerator_value} / {strength.denominator_value}</span>
     </div>
-  {/each}
+  {/each} -->
 </div>
 
 <style>
@@ -62,36 +71,5 @@
     font-size: 1.5rem;
     font-weight: bold;
     margin-bottom: 10px;
-  }
-
-  .drug-row {
-    display: flex;
-    align-items: center;
-    padding: 8px 0;
-    flex-wrap: wrap;
-    font-size: 1rem;
-    background: #fff;
-    border-bottom: 1px solid #ddd;
-    white-space: nowrap;
-  }
-
-  .exposure {
-    background: #fff;
-  }
-
-  .strength {
-    background: #fff;
-  }
-
-  .info {
-    font-weight: normal;
-    font-size: 1.1rem;
-    margin-right: 10px;
-  }
-
-  .divider {
-    color: #888;
-    font-weight: bold;
-    margin: 0 10px;
   }
 </style>

--- a/frontend/src/lib/components/Table/Measurement.svelte
+++ b/frontend/src/lib/components/Table/Measurement.svelte
@@ -36,7 +36,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }
@@ -54,7 +54,7 @@
 
   .info {
     font-weight: normal;
-    font-size: 1.1rem;
+    font-size: 1.0rem;
     margin-right: 10px;
   }
 

--- a/frontend/src/lib/components/Table/Observation.svelte
+++ b/frontend/src/lib/components/Table/Observation.svelte
@@ -7,8 +7,6 @@
 
   {#each observation as obs}
     <div class="observation-row">
-      <span class="info"><strong>Observation ID:</strong> {obs.observation_id}</span>
-      <span class="divider">|</span>
       <span class="info"><strong>Date:</strong> {obs.observation_date}</span>
       <span class="divider">|</span>
       <span class="info"><strong>Concept ID:</strong> {obs.observation_concept_id}</span>
@@ -32,7 +30,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }
@@ -50,7 +48,7 @@
 
   .info {
     font-weight: normal;
-    font-size: 1.1rem;
+    font-size: 1.0rem;
     margin-right: 10px;
   }
 

--- a/frontend/src/lib/components/Table/ProcedureOccurrence.svelte
+++ b/frontend/src/lib/components/Table/ProcedureOccurrence.svelte
@@ -7,8 +7,6 @@
 
   {#each procedureOccurrence as proc}
     <div class="procedure-row">
-      <span class="info"><strong>Procedure ID:</strong> {proc.procedure_occurrence_id}</span>
-      <span class="divider">|</span>
       <span class="info"><strong>Date:</strong> {proc.procedure_date}</span>
       <span class="divider">|</span>
       <span class="info"><strong>Concept ID:</strong> 
@@ -36,7 +34,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }
@@ -54,7 +52,7 @@
 
   .info {
     font-weight: normal;
-    font-size: 1.1rem;
+    font-size: 1.0rem;
     margin-right: 10px;
   }
 

--- a/frontend/src/lib/components/Table/Specimen.svelte
+++ b/frontend/src/lib/components/Table/Specimen.svelte
@@ -7,8 +7,6 @@
 
   {#each specimen as spec}
     <div class="specimen-row">
-      <span class="info"><strong>Specimen ID:</strong> {spec.specimen_id}</span>
-      <span class="divider">|</span>
       <span class="info"><strong>Date:</strong> {spec.specimen_date}</span>
       <span class="divider">|</span>
       <span class="info"><strong>Concept ID:</strong> 
@@ -34,7 +32,7 @@
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 1.3rem;
     font-weight: bold;
     margin-bottom: 10px;
   }
@@ -52,7 +50,7 @@
 
   .info {
     font-weight: normal;
-    font-size: 1.1rem;
+    font-size: 1.0rem;
     margin-right: 10px;
   }
 

--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -24,7 +24,7 @@
     let timelineContainer;
     let showModal = false;
     let isStatisticsView = true;
-    let selectedTables = new Set();
+    let show = false;
     export let data;
 
     let isTableView = {
@@ -52,6 +52,8 @@
         specimen: Specimen,
         bio_signal: BioSignal
     };
+
+    let selectedTables = new Set(Object.keys(tableComponents)); // Object.keys(tableComponents)
 
     //   데이터 매칭 (각 테이블에 해당하는 props 설정)
     let tableProps = {};
@@ -93,7 +95,7 @@
             tableProps = {
                 cdm_info: { careSite: visitOccurrenceIdData.care_site, location: visitOccurrenceIdData.location, visitOccurrence: visitOccurrenceIdData.visit_occurrence },
                 condition: { conditionEra: visitOccurrenceIdData.condition_era, conditionOccurrence: visitOccurrenceIdData.condition_occurrence },
-                drug: { drugEra: visitOccurrenceIdData.drug_era, drugExposure: visitOccurrenceIdData.drug_exposure, drugStrength: visitOccurrenceIdData.drug_strength },
+                drug: { drugExposure: visitOccurrenceIdData.drug_exposure },
                 measurement: { measurement: visitOccurrenceIdData.measurement },
                 observation: { observation: visitOccurrenceIdData.observation },
                 procedure_occurrence: { procedureOccurrence: visitOccurrenceIdData.procedure_occurrence },
@@ -158,14 +160,14 @@
     }
 
     function setupClipPath(svg) {
-    svg.append("defs")
-            .append("clipPath")
-            .attr("id", "clip-timeline")
-            .append("rect")
-            .attr("x", MARGIN.left)
-            .attr("y", 0)
-            .attr("width", innerWidth)
-            .attr("height", innerHeight);
+        svg.append("defs")
+                .append("clipPath")
+                .attr("id", "clip-timeline")
+                .append("rect")
+                .attr("x", MARGIN.left)
+                .attr("y", 0)
+                .attr("width", innerWidth)
+                .attr("height", innerHeight);
     }
 
     function setupTooltip() {
@@ -301,6 +303,10 @@
             });
 
         svg.call(zoom);
+    }
+
+    function notify() {
+        alert("테이블을 선택해주세요.");
     }
 
     onMount(() => {
@@ -511,12 +517,12 @@
         </button>
         {#if tableProps?.cdm_info}
             <CDMInfo careSite={tableProps["cdm_info"].careSite} location={tableProps["cdm_info"].location} visitOccurrence={tableProps["cdm_info"].visitOccurrence} />
+            {#each Array.from(selectedTables) as tableId}
+                {#if tableComponents[tableId]}
+                    <svelte:component this={tableComponents[tableId]} {...tableProps[tableId]} />
+                {/if}
+            {/each}
         {/if}
-        {#each Array.from(selectedTables) as tableId}
-            {#if tableComponents[tableId]}
-                <svelte:component this={tableComponents[tableId]} {...tableProps[tableId]} />
-            {/if}
-        {/each}
     {/if}
 </div>
 

--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -367,7 +367,7 @@
     <!-- 🔹 타임라인을 렌더링할 컨테이너 -->
     <div class="w-full h-[200px] min-w-[850px]" bind:this={timelineContainer}></div>
 </header>
-<div class="pt-8 pb-[60px] flex flex-col">
+<div class="pt-8 pb-[60px] flex flex-col gap-5">
     {#if !isStatisticsView}
         <div class="w-full">
             <div class="grid grid-cols-2 gap-4">

--- a/frontend/static/cdm_sample_data.json
+++ b/frontend/static/cdm_sample_data.json
@@ -44,17 +44,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3001,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4001,
@@ -64,15 +53,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 47237,
+        "drug_concept_id": 4577,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 45355,
+        "drug_concept_id": 9553,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -93,7 +115,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4001
       }
     ],
@@ -197,17 +219,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3002,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4002,
@@ -217,15 +228,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 18671,
+        "drug_concept_id": 6532,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 81481,
+        "drug_concept_id": 3746,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -246,7 +290,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4002
       }
     ],
@@ -350,17 +394,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3003,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4003,
@@ -370,15 +403,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 30617,
+        "drug_concept_id": 1594,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 25631,
+        "drug_concept_id": 8270,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -399,7 +465,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4003
       }
     ],
@@ -503,17 +569,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3004,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4004,
@@ -523,15 +578,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 82368,
+        "drug_concept_id": 4128,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 83403,
+        "drug_concept_id": 9907,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -552,7 +640,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4004
       }
     ],
@@ -656,17 +744,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3005,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4005,
@@ -676,15 +753,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 19907,
+        "drug_concept_id": 6145,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 36844,
+        "drug_concept_id": 2339,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -705,7 +815,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4005
       }
     ],
@@ -809,17 +919,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3006,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4006,
@@ -829,15 +928,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 19331,
+        "drug_concept_id": 3105,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 54886,
+        "drug_concept_id": 8721,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -858,7 +990,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4006
       }
     ],
@@ -962,17 +1094,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3007,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4007,
@@ -982,15 +1103,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 73655,
+        "drug_concept_id": 1441,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 55838,
+        "drug_concept_id": 4111,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1011,7 +1165,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4007
       }
     ],
@@ -1115,17 +1269,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3008,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4008,
@@ -1135,15 +1278,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 89330,
+        "drug_concept_id": 4226,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 23875,
+        "drug_concept_id": 3911,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1164,7 +1340,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4008
       }
     ],
@@ -1268,17 +1444,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3009,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4009,
@@ -1288,15 +1453,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 30609,
+        "drug_concept_id": 3092,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 43822,
+        "drug_concept_id": 3571,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1317,7 +1515,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4009
       }
     ],
@@ -1421,17 +1619,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3010,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4010,
@@ -1441,15 +1628,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 16134,
+        "drug_concept_id": 5706,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 46008,
+        "drug_concept_id": 9635,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1470,7 +1690,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4010
       }
     ],
@@ -1574,17 +1794,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3011,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4011,
@@ -1594,15 +1803,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 69116,
+        "drug_concept_id": 2517,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 73697,
+        "drug_concept_id": 6059,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1623,7 +1865,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4011
       }
     ],
@@ -1727,17 +1969,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3012,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4012,
@@ -1747,15 +1978,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 40398,
+        "drug_concept_id": 3768,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 59262,
+        "drug_concept_id": 6710,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1776,7 +2040,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4012
       }
     ],
@@ -1880,17 +2144,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3013,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4013,
@@ -1900,15 +2153,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 73647,
+        "drug_concept_id": 4587,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 99690,
+        "drug_concept_id": 5951,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -1929,7 +2215,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4013
       }
     ],
@@ -2033,17 +2319,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3014,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4014,
@@ -2053,15 +2328,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 37967,
+        "drug_concept_id": 1836,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 91124,
+        "drug_concept_id": 4477,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -2082,7 +2390,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4014
       }
     ],
@@ -2186,17 +2494,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3015,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4015,
@@ -2206,15 +2503,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 19614,
+        "drug_concept_id": 3214,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 47439,
+        "drug_concept_id": 8097,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -2235,7 +2565,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4015
       }
     ],
@@ -2339,17 +2669,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3016,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4016,
@@ -2359,15 +2678,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 81575,
+        "drug_concept_id": 1182,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 83205,
+        "drug_concept_id": 5217,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -2388,7 +2740,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4016
       }
     ],
@@ -2492,17 +2844,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3017,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4017,
@@ -2512,15 +2853,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 38097,
+        "drug_concept_id": 9290,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 57957,
+        "drug_concept_id": 8673,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -2541,7 +2915,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4017
       }
     ],
@@ -2645,17 +3019,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3018,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4018,
@@ -2665,15 +3028,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 56823,
+        "drug_concept_id": 7945,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 49121,
+        "drug_concept_id": 9414,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -2694,7 +3090,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4018
       }
     ],
@@ -2798,17 +3194,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3019,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4019,
@@ -2818,15 +3203,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 21521,
+        "drug_concept_id": 1529,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 96879,
+        "drug_concept_id": 3900,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -2847,7 +3265,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4019
       }
     ],
@@ -2951,17 +3369,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3020,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4020,
@@ -2971,15 +3378,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 61124,
+        "drug_concept_id": 4280,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 67839,
+        "drug_concept_id": 6049,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3000,7 +3440,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4020
       }
     ],
@@ -3104,17 +3544,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3021,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4021,
@@ -3124,15 +3553,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 55845,
+        "drug_concept_id": 2445,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 77330,
+        "drug_concept_id": 5540,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3153,7 +3615,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4021
       }
     ],
@@ -3257,17 +3719,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3022,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4022,
@@ -3277,15 +3728,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 62476,
+        "drug_concept_id": 5087,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 45925,
+        "drug_concept_id": 3056,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3306,7 +3790,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4022
       }
     ],
@@ -3410,17 +3894,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3023,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4023,
@@ -3430,15 +3903,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 84866,
+        "drug_concept_id": 8220,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 88361,
+        "drug_concept_id": 1919,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3459,7 +3965,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4023
       }
     ],
@@ -3563,17 +4069,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3024,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4024,
@@ -3583,15 +4078,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 51169,
+        "drug_concept_id": 5888,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 27156,
+        "drug_concept_id": 2971,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3612,7 +4140,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4024
       }
     ],
@@ -3716,17 +4244,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3025,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4025,
@@ -3736,15 +4253,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 48784,
+        "drug_concept_id": 2698,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 20621,
+        "drug_concept_id": 1213,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3765,7 +4315,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4025
       }
     ],
@@ -3869,17 +4419,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3026,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4026,
@@ -3889,15 +4428,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 21602,
+        "drug_concept_id": 1230,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 60066,
+        "drug_concept_id": 9075,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -3918,7 +4490,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4026
       }
     ],
@@ -4022,17 +4594,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3027,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4027,
@@ -4042,15 +4603,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 35265,
+        "drug_concept_id": 8884,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 96362,
+        "drug_concept_id": 8679,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4071,7 +4665,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4027
       }
     ],
@@ -4175,17 +4769,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3028,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4028,
@@ -4195,15 +4778,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 59736,
+        "drug_concept_id": 3044,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 37349,
+        "drug_concept_id": 9471,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4224,7 +4840,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4028
       }
     ],
@@ -4328,17 +4944,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3029,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4029,
@@ -4348,15 +4953,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 93013,
+        "drug_concept_id": 4320,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 15891,
+        "drug_concept_id": 7804,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4377,7 +5015,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4029
       }
     ],
@@ -4481,17 +5119,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3030,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4030,
@@ -4501,15 +5128,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 88874,
+        "drug_concept_id": 7315,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 84544,
+        "drug_concept_id": 5077,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4530,7 +5190,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4030
       }
     ],
@@ -4634,17 +5294,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3031,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4031,
@@ -4654,15 +5303,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 40359,
+        "drug_concept_id": 2923,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 48674,
+        "drug_concept_id": 1495,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4683,7 +5365,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4031
       }
     ],
@@ -4787,17 +5469,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3032,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4032,
@@ -4807,15 +5478,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 24758,
+        "drug_concept_id": 1334,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 65006,
+        "drug_concept_id": 5898,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4836,7 +5540,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4032
       }
     ],
@@ -4940,17 +5644,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3033,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4033,
@@ -4960,15 +5653,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 56907,
+        "drug_concept_id": 9113,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 60425,
+        "drug_concept_id": 4985,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -4989,7 +5715,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4033
       }
     ],
@@ -5093,17 +5819,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3034,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4034,
@@ -5113,15 +5828,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 90851,
+        "drug_concept_id": 3883,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 80314,
+        "drug_concept_id": 6036,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -5142,7 +5890,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4034
       }
     ],
@@ -5246,17 +5994,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3035,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4035,
@@ -5266,15 +6003,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 51828,
+        "drug_concept_id": 1214,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 34611,
+        "drug_concept_id": 1751,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -5295,7 +6065,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4035
       }
     ],
@@ -5399,17 +6169,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3036,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4036,
@@ -5419,15 +6178,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 44033,
+        "drug_concept_id": 4623,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 71550,
+        "drug_concept_id": 8428,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -5448,7 +6240,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4036
       }
     ],
@@ -5552,17 +6344,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3037,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4037,
@@ -5572,15 +6353,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 37656,
+        "drug_concept_id": 6677,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 74830,
+        "drug_concept_id": 3478,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -5601,7 +6415,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4037
       }
     ],
@@ -5705,17 +6519,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3038,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4038,
@@ -5725,15 +6528,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 17370,
+        "drug_concept_id": 1033,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 34784,
+        "drug_concept_id": 3595,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -5754,7 +6590,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4038
       }
     ],
@@ -5858,17 +6694,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3039,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4039,
@@ -5878,15 +6703,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 72898,
+        "drug_concept_id": 8683,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 56454,
+        "drug_concept_id": 7445,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -5907,7 +6765,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4039
       }
     ],
@@ -6011,17 +6869,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3040,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4040,
@@ -6031,15 +6878,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 72600,
+        "drug_concept_id": 9010,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 15917,
+        "drug_concept_id": 3872,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6060,7 +6940,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4040
       }
     ],
@@ -6164,17 +7044,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3041,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4041,
@@ -6184,15 +7053,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 22205,
+        "drug_concept_id": 7593,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 80197,
+        "drug_concept_id": 9421,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6213,7 +7115,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4041
       }
     ],
@@ -6317,17 +7219,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3042,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4042,
@@ -6337,15 +7228,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 19738,
+        "drug_concept_id": 1442,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 84022,
+        "drug_concept_id": 8941,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6366,7 +7290,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4042
       }
     ],
@@ -6470,17 +7394,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3043,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4043,
@@ -6490,15 +7403,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 42404,
+        "drug_concept_id": 2308,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 54829,
+        "drug_concept_id": 9170,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6519,7 +7465,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4043
       }
     ],
@@ -6623,17 +7569,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3044,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4044,
@@ -6643,15 +7578,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 55215,
+        "drug_concept_id": 8884,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 13140,
+        "drug_concept_id": 2217,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6672,7 +7640,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4044
       }
     ],
@@ -6776,17 +7744,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3045,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4045,
@@ -6796,15 +7753,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 25430,
+        "drug_concept_id": 6718,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 45136,
+        "drug_concept_id": 8004,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6825,7 +7815,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4045
       }
     ],
@@ -6929,17 +7919,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3046,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4046,
@@ -6949,15 +7928,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 75174,
+        "drug_concept_id": 7984,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 98712,
+        "drug_concept_id": 2639,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -6978,7 +7990,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4046
       }
     ],
@@ -7082,17 +8094,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3047,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4047,
@@ -7102,15 +8103,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 36051,
+        "drug_concept_id": 6891,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 29806,
+        "drug_concept_id": 5234,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -7131,7 +8165,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4047
       }
     ],
@@ -7235,17 +8269,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3048,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4048,
@@ -7255,15 +8278,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 48834,
+        "drug_concept_id": 2282,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 27562,
+        "drug_concept_id": 8755,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -7284,7 +8340,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4048
       }
     ],
@@ -7388,17 +8444,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3049,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4049,
@@ -7408,15 +8453,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 28978,
+        "drug_concept_id": 1378,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 43749,
+        "drug_concept_id": 4356,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -7437,7 +8515,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4049
       }
     ],
@@ -7541,17 +8619,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3050,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4050,
@@ -7561,15 +8628,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 56560,
+        "drug_concept_id": 7968,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 10231,
+        "drug_concept_id": 5554,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -7590,7 +8690,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4050
       }
     ],
@@ -7694,17 +8794,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3051,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4051,
@@ -7714,15 +8803,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 63466,
+        "drug_concept_id": 2855,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 64121,
+        "drug_concept_id": 8937,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -7743,7 +8865,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4051
       }
     ],
@@ -7847,17 +8969,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3052,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4052,
@@ -7867,15 +8978,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 66635,
+        "drug_concept_id": 6370,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 72208,
+        "drug_concept_id": 5383,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -7896,7 +9040,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4052
       }
     ],
@@ -8000,17 +9144,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3053,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4053,
@@ -8020,15 +9153,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 67978,
+        "drug_concept_id": 8908,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 14953,
+        "drug_concept_id": 3289,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8049,7 +9215,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4053
       }
     ],
@@ -8153,17 +9319,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3054,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4054,
@@ -8173,15 +9328,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 80026,
+        "drug_concept_id": 3333,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 40260,
+        "drug_concept_id": 3395,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8202,7 +9390,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4054
       }
     ],
@@ -8306,17 +9494,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3055,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4055,
@@ -8326,15 +9503,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 96869,
+        "drug_concept_id": 6391,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 76840,
+        "drug_concept_id": 2647,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8355,7 +9565,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4055
       }
     ],
@@ -8459,17 +9669,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3056,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4056,
@@ -8479,15 +9678,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 64360,
+        "drug_concept_id": 9177,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 40665,
+        "drug_concept_id": 7331,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8508,7 +9740,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4056
       }
     ],
@@ -8612,17 +9844,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3057,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4057,
@@ -8632,15 +9853,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 69913,
+        "drug_concept_id": 2685,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 98590,
+        "drug_concept_id": 1834,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8661,7 +9915,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4057
       }
     ],
@@ -8765,17 +10019,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3058,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4058,
@@ -8785,15 +10028,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 90098,
+        "drug_concept_id": 9558,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 54714,
+        "drug_concept_id": 9695,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8814,7 +10090,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4058
       }
     ],
@@ -8918,17 +10194,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3059,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4059,
@@ -8938,15 +10203,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 56307,
+        "drug_concept_id": 7424,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 67168,
+        "drug_concept_id": 1946,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -8967,7 +10265,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4059
       }
     ],
@@ -9071,17 +10369,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3060,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4060,
@@ -9091,15 +10378,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 57300,
+        "drug_concept_id": 5861,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 19715,
+        "drug_concept_id": 5986,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -9120,7 +10440,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4060
       }
     ],
@@ -9224,17 +10544,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3061,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4061,
@@ -9244,15 +10553,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 65896,
+        "drug_concept_id": 9251,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 16816,
+        "drug_concept_id": 4782,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -9273,7 +10615,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4061
       }
     ],
@@ -9377,17 +10719,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3062,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4062,
@@ -9397,15 +10728,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 94496,
+        "drug_concept_id": 2391,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 50961,
+        "drug_concept_id": 4543,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -9426,7 +10790,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4062
       }
     ],
@@ -9530,17 +10894,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3063,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4063,
@@ -9550,15 +10903,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 64240,
+        "drug_concept_id": 6227,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 99901,
+        "drug_concept_id": 4899,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -9579,7 +10965,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4063
       }
     ],
@@ -9683,17 +11069,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3064,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4064,
@@ -9703,15 +11078,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 14117,
+        "drug_concept_id": 7668,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 99918,
+        "drug_concept_id": 5386,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -9732,7 +11140,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4064
       }
     ],
@@ -9836,17 +11244,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3065,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4065,
@@ -9856,15 +11253,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 24583,
+        "drug_concept_id": 3040,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 16614,
+        "drug_concept_id": 7631,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -9885,7 +11315,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4065
       }
     ],
@@ -9989,17 +11419,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3066,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4066,
@@ -10009,15 +11428,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 73840,
+        "drug_concept_id": 5047,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 15746,
+        "drug_concept_id": 2290,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10038,7 +11490,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4066
       }
     ],
@@ -10142,17 +11594,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3067,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4067,
@@ -10162,15 +11603,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 25287,
+        "drug_concept_id": 8140,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 66974,
+        "drug_concept_id": 4655,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10191,7 +11665,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4067
       }
     ],
@@ -10295,17 +11769,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3068,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4068,
@@ -10315,15 +11778,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 75454,
+        "drug_concept_id": 9149,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 87344,
+        "drug_concept_id": 6888,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10344,7 +11840,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4068
       }
     ],
@@ -10448,17 +11944,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3069,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4069,
@@ -10468,15 +11953,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 65421,
+        "drug_concept_id": 1170,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 70435,
+        "drug_concept_id": 6186,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10497,7 +12015,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4069
       }
     ],
@@ -10601,17 +12119,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3070,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4070,
@@ -10621,15 +12128,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 97254,
+        "drug_concept_id": 8159,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 12326,
+        "drug_concept_id": 4756,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10650,7 +12190,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4070
       }
     ],
@@ -10754,17 +12294,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3071,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4071,
@@ -10774,15 +12303,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 87216,
+        "drug_concept_id": 3397,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 40696,
+        "drug_concept_id": 2530,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10803,7 +12365,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4071
       }
     ],
@@ -10907,17 +12469,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3072,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4072,
@@ -10927,15 +12478,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 87624,
+        "drug_concept_id": 3353,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 89026,
+        "drug_concept_id": 4522,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -10956,7 +12540,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4072
       }
     ],
@@ -11060,17 +12644,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3073,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4073,
@@ -11080,15 +12653,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 11246,
+        "drug_concept_id": 2608,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 94145,
+        "drug_concept_id": 8641,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -11109,7 +12715,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4073
       }
     ],
@@ -11213,17 +12819,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3074,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4074,
@@ -11233,15 +12828,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 78884,
+        "drug_concept_id": 3457,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 79209,
+        "drug_concept_id": 1531,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -11262,7 +12890,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4074
       }
     ],
@@ -11366,17 +12994,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3075,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4075,
@@ -11386,15 +13003,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 49363,
+        "drug_concept_id": 4554,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 38419,
+        "drug_concept_id": 9838,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -11415,7 +13065,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4075
       }
     ],
@@ -11519,17 +13169,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3076,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4076,
@@ -11539,15 +13178,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 38279,
+        "drug_concept_id": 7962,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 57006,
+        "drug_concept_id": 3015,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -11568,7 +13240,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4076
       }
     ],
@@ -11672,17 +13344,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3077,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4077,
@@ -11692,15 +13353,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 73181,
+        "drug_concept_id": 1867,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 11430,
+        "drug_concept_id": 3132,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -11721,7 +13415,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4077
       }
     ],
@@ -11825,17 +13519,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3078,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4078,
@@ -11845,15 +13528,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 68014,
+        "drug_concept_id": 4521,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 75184,
+        "drug_concept_id": 4208,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -11874,7 +13590,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4078
       }
     ],
@@ -11978,17 +13694,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3079,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4079,
@@ -11998,15 +13703,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 59698,
+        "drug_concept_id": 6129,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 41668,
+        "drug_concept_id": 8803,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12027,7 +13765,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4079
       }
     ],
@@ -12131,17 +13869,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3080,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4080,
@@ -12151,15 +13878,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 21761,
+        "drug_concept_id": 9994,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 37145,
+        "drug_concept_id": 1196,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12180,7 +13940,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4080
       }
     ],
@@ -12284,17 +14044,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3081,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4081,
@@ -12304,15 +14053,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 67452,
+        "drug_concept_id": 4849,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 92823,
+        "drug_concept_id": 3804,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12333,7 +14115,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4081
       }
     ],
@@ -12437,17 +14219,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3082,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4082,
@@ -12457,15 +14228,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 87639,
+        "drug_concept_id": 3898,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 11134,
+        "drug_concept_id": 5806,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12486,7 +14290,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4082
       }
     ],
@@ -12590,17 +14394,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3083,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4083,
@@ -12610,15 +14403,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 23286,
+        "drug_concept_id": 4590,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 75440,
+        "drug_concept_id": 5716,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12639,7 +14465,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4083
       }
     ],
@@ -12743,17 +14569,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3084,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4084,
@@ -12763,15 +14578,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 43560,
+        "drug_concept_id": 3252,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 75891,
+        "drug_concept_id": 2929,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12792,7 +14640,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4084
       }
     ],
@@ -12896,17 +14744,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3085,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4085,
@@ -12916,15 +14753,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 95000,
+        "drug_concept_id": 4441,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 80682,
+        "drug_concept_id": 5421,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -12945,7 +14815,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4085
       }
     ],
@@ -13049,17 +14919,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3086,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4086,
@@ -13069,15 +14928,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 53150,
+        "drug_concept_id": 5796,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 28833,
+        "drug_concept_id": 6359,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -13098,7 +14990,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4086
       }
     ],
@@ -13202,17 +15094,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3087,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4087,
@@ -13222,15 +15103,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 90893,
+        "drug_concept_id": 8282,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 25952,
+        "drug_concept_id": 5947,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -13251,7 +15165,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4087
       }
     ],
@@ -13355,17 +15269,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3088,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4088,
@@ -13375,15 +15278,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 10812,
+        "drug_concept_id": 1128,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 36912,
+        "drug_concept_id": 7903,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -13404,7 +15340,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4088
       }
     ],
@@ -13508,17 +15444,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3089,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4089,
@@ -13528,15 +15453,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 13595,
+        "drug_concept_id": 4293,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 66968,
+        "drug_concept_id": 9269,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -13557,7 +15515,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4089
       }
     ],
@@ -13661,17 +15619,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3090,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4090,
@@ -13681,15 +15628,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 27043,
+        "drug_concept_id": 9854,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 97944,
+        "drug_concept_id": 5692,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -13710,7 +15690,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4090
       }
     ],
@@ -13814,17 +15794,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3091,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4091,
@@ -13834,15 +15803,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 28149,
+        "drug_concept_id": 7946,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 91072,
+        "drug_concept_id": 8117,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -13863,7 +15865,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4091
       }
     ],
@@ -13967,17 +15969,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3092,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4092,
@@ -13987,15 +15978,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 38660,
+        "drug_concept_id": 4483,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 61572,
+        "drug_concept_id": 3307,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14016,7 +16040,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4092
       }
     ],
@@ -14120,17 +16144,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3093,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4093,
@@ -14140,15 +16153,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 89104,
+        "drug_concept_id": 3268,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 80694,
+        "drug_concept_id": 5556,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14169,7 +16215,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4093
       }
     ],
@@ -14273,17 +16319,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3094,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4094,
@@ -14293,15 +16328,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 71395,
+        "drug_concept_id": 6160,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 77253,
+        "drug_concept_id": 6104,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14322,7 +16390,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4094
       }
     ],
@@ -14426,17 +16494,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3095,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4095,
@@ -14446,15 +16503,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 84458,
+        "drug_concept_id": 8349,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 36133,
+        "drug_concept_id": 2763,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14475,7 +16565,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4095
       }
     ],
@@ -14579,17 +16669,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3096,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4096,
@@ -14599,15 +16678,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 70494,
+        "drug_concept_id": 1653,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 81221,
+        "drug_concept_id": 2741,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14628,7 +16740,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4096
       }
     ],
@@ -14732,17 +16844,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3097,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4097,
@@ -14752,15 +16853,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 15822,
+        "drug_concept_id": 8580,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 73127,
+        "drug_concept_id": 4287,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14781,7 +16915,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4097
       }
     ],
@@ -14885,17 +17019,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3098,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4098,
@@ -14905,15 +17028,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 53845,
+        "drug_concept_id": 8530,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 87511,
+        "drug_concept_id": 9228,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -14934,7 +17090,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4098
       }
     ],
@@ -15038,17 +17194,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3099,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4099,
@@ -15058,15 +17203,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 14089,
+        "drug_concept_id": 5850,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 13899,
+        "drug_concept_id": 4361,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -15087,7 +17265,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4099
       }
     ],
@@ -15191,17 +17369,6 @@
         "condition_occurrence_count": 3
       }
     ],
-    "drug_era": [
-      {
-        "drug_era_id": 3100,
-        "person_id": 1,
-        "drug_concept_id": 19019073,
-        "drug_era_start_date": "2024-01-10",
-        "drug_era_end_date": "2024-06-10",
-        "drug_exposure_count": 90,
-        "gap_days": 5
-      }
-    ],
     "drug_exposure": [
       {
         "drug_exposure_id": 4100,
@@ -15211,15 +17378,48 @@
         "drug_exposure_end_date": "2024-01-20",
         "quantity": 10,
         "days_supply": 10
-      }
-    ],
-    "drug_strength": [
+      },
       {
-        "drug_concept_id": 19019073,
-        "ingredient_concept_id": 1125315,
-        "amount_value": 50,
-        "numerator_value": 50,
-        "denominator_value": 1
+        "drug_exposure_id": 16564,
+        "drug_concept_id": 5895,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
+      },
+      {
+        "drug_exposure_id": 47952,
+        "drug_concept_id": 5327,
+        "drug_exposure_start_date": "2024-01-01",
+        "drug_exposure_end_date": "2024-01-10",
+        "drug_type_concept_id": 38000177,
+        "stop_reason": null,
+        "refills": 0,
+        "quantity": 30,
+        "days_supply": 10,
+        "sig": null,
+        "route_concept_id": 0,
+        "lot_number": null,
+        "provider_id": null,
+        "visit_occurrence_id": null,
+        "visit_detail_id": null,
+        "drug_source_value": "TestDrug",
+        "drug_source_concept_id": 0,
+        "route_source_value": null,
+        "dose_unit_source_value": "mg"
       }
     ],
     "measurement": [
@@ -15240,7 +17440,7 @@
         "person_id": 1,
         "observation_concept_id": 4013886,
         "observation_date": "2024-03-10",
-        "value_as_string": "\ud761\uc5f0\uc790",
+        "value_as_string": "흡연자",
         "visit_occurrence_id": 4100
       }
     ],


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#50 

## 📝 작업 내용
1. Drug Exposure 테스트 데이터를 추가하여 기존 텍스트 나열 형태가 아닌 여러 개의 Drug 데이터가 들어오더라도 쉽게 볼 수 있게끔 테이블 형태로 구현.
2. 카드별 gap을 추가하여 가독성 증가
3. font size 조절


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/bddc60c1-5153-4094-8ceb-e14157dca71c)
![image](https://github.com/user-attachments/assets/f4d48550-e4e6-4bfa-80ca-1055591e473c)

## 💬 리뷰 요구사항(선택)
font 사이즈와 gap을 각각 title : 1.3rem, info : 1.0rem으로 줬고, gap: 5로 줬는데 적당한지 체크 부탁드립니다!

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
