### PR TITLE
Feat: 코호트 ID 검색 및 페이지네이션 구현

### DIFF
--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -9,7 +9,7 @@
 	let searchQuery = $state("");
 	let filteredData = $state([]);
 	let itemsPerPage = $state(10);
-	let currentPage = $state(1);
+	let currentPage = $state(0);
 	let paginatedData = $state([]);
 
 	const rowHeight = 42;
@@ -31,8 +31,11 @@
 	}
 
 	onMount(() => {
-		filteredData = data.userData;
-		calculateItemsPerPage();
+		if(data.userData.length !== 0){
+			currentPage = 1;
+			filteredData = data.userData;
+			calculateItemsPerPage();
+		}
 		window.addEventListener('resize', calculateItemsPerPage);
 	});
 
@@ -92,7 +95,7 @@
 		<!-- Pagination -->
 		<div class="flex justify-between px-2 py-2 text-xs">
 			<button onclick={prevPage} disabled={currentPage === 1} class="text-blue-600 disabled:text-gray-300">{"<"}</button>
-			<span>Page {currentPage} / {Math.ceil(filteredData.length / itemsPerPage)}</span>
+			<span>Page {currentPage} / {Math.ceil((filteredData.length ? filteredData.length : 1) / itemsPerPage)}</span>
 			<button onclick={nextPage} disabled={currentPage * itemsPerPage >= filteredData.length} class="text-blue-600 disabled:text-gray-300">{">"}</button>
 		</div>
 	</div>

--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -1,10 +1,29 @@
 <script>
     import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
+	import { filter } from 'd3';
+	import { onMount } from 'svelte';
 
+	let { children, data } = $props();
     const cohortID = $page.params.cohortID;
+	let searchQuery = $state("");
+	let filteredData = $state([]);
+	
+	// 검색어에 따라 데이터를 필터링
+	function filterData() {
+		if(searchQuery.length === 0){
+			filteredData = data.userData;
+			return;	
+		}
 
-    let { children, data } = $props();
+		filteredData = data.userData.filter((item) =>
+			item.personid === parseInt(searchQuery)
+		);
+	}
+
+	onMount(() => {
+		filteredData = data.userData;
+	});
 </script>
 
 <div class="fixed left-0 top-10 flex h-full w-[200px] flex-col border-r border-zinc-200">
@@ -22,19 +41,24 @@
 		<input
 			type="text"
 			class="h-8 w-full rounded-sm border border-zinc-200 bg-zinc-50 text-left shadow-sm placeholder:text-xs text-xs"
-			placeholder="유저 ID를 입력하세요."
+			placeholder="Enter Person ID"
+			bind:value={searchQuery}
+			onkeydown={(e) => {
+				if(e.key === "Enter") filterData();
+			}}
 		/>
-
-		<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
+		<button onclick={filterData} aria-label="Search-Person-ID">
+			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
 				<path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
 			</svg>
+		</button>
 	</div>
 	<div class="h-full w-full px-2">
 		<div class="flex flex-col rounded-sm border-r border-t border-l border-zinc-200 bg-zinc-50 max-h-full overflow-y-auto">
-			{#each data.userData as user}
+			{#each filteredData as user}
 				<a href="/cohort/{cohortID}/{user.personid}">
 					<button class="w-full border-b border-zinc-200 px-2 py-2 text-left text-xs overflow-wrap">
-						{user.gender} (만 {user.age}) | {user.id}
+						{user.gender} (만 {user.age}) | {user.personid}
 					</button>
 				</a>
 			{/each}

--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -91,9 +91,9 @@
 
 		<!-- Pagination -->
 		<div class="flex justify-between px-2 py-2 text-xs">
-			<button onclick={prevPage} disabled={currentPage === 1} class="text-blue-600 disabled:text-gray-300">Previous</button>
+			<button onclick={prevPage} disabled={currentPage === 1} class="text-blue-600 disabled:text-gray-300">{"<"}</button>
 			<span>Page {currentPage} / {Math.ceil(filteredData.length / itemsPerPage)}</span>
-			<button onclick={nextPage} disabled={currentPage * itemsPerPage >= filteredData.length} class="text-blue-600 disabled:text-gray-300">Next</button>
+			<button onclick={nextPage} disabled={currentPage * itemsPerPage >= filteredData.length} class="text-blue-600 disabled:text-gray-300">{">"}</button>
 		</div>
 	</div>
 </div>

--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -8,7 +8,16 @@
     const cohortID = $page.params.cohortID;
 	let searchQuery = $state("");
 	let filteredData = $state([]);
-	
+	let itemsPerPage = $state(10);
+	let currentPage = $state(1);
+	let paginatedData = $state([]);
+
+	const rowHeight = 42;
+
+	function calculateItemsPerPage() {
+		const availableHeight = window.innerHeight - 50;
+		itemsPerPage = Math.floor(availableHeight / rowHeight);
+	}
 	// 검색어에 따라 데이터를 필터링
 	function filterData() {
 		if(searchQuery.length === 0){
@@ -23,7 +32,23 @@
 
 	onMount(() => {
 		filteredData = data.userData;
+		calculateItemsPerPage();
+		window.addEventListener('resize', calculateItemsPerPage);
 	});
+
+	$effect(() => {
+		paginatedData = filteredData.slice(
+			(currentPage - 1) * itemsPerPage,
+			currentPage * itemsPerPage
+		);
+	})
+
+	function nextPage() {
+		if (currentPage * itemsPerPage < filteredData.length) currentPage++;
+	}
+	function prevPage() {
+		if (currentPage > 1) currentPage--;
+	}
 </script>
 
 <div class="fixed left-0 top-10 flex h-full w-[200px] flex-col border-r border-zinc-200">
@@ -55,13 +80,20 @@
 	</div>
 	<div class="h-full w-full px-2">
 		<div class="flex flex-col rounded-sm border-r border-t border-l border-zinc-200 bg-zinc-50 max-h-full overflow-y-auto">
-			{#each filteredData as user}
+			{#each paginatedData as user}
 				<a href="/cohort/{cohortID}/{user.personid}">
 					<button class="w-full border-b border-zinc-200 px-2 py-2 text-left text-xs overflow-wrap">
-						{user.gender} (만 {user.age}) | {user.personid}
+						{user.gender} ({user.age}) | {user.personid}
 					</button>
 				</a>
 			{/each}
+		</div>
+
+		<!-- Pagination -->
+		<div class="flex justify-between px-2 py-2 text-xs">
+			<button onclick={prevPage} disabled={currentPage === 1} class="text-blue-600 disabled:text-gray-300">Previous</button>
+			<span>Page {currentPage} / {Math.ceil(filteredData.length / itemsPerPage)}</span>
+			<button onclick={nextPage} disabled={currentPage * itemsPerPage >= filteredData.length} class="text-blue-600 disabled:text-gray-300">Next</button>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#54 

## 📝 작업 내용
단일 코호트에서 Person ID로 검색하는 기능을 구현. input box 옆에 버튼을 클릭하거나, Enter 를 클릭하여 검색할 수 있음.
기존 스크롤로 보여주던 코호트에 해당하는 Person Data들을 페이지네이션을 추가하여 보여줌. window.innerHeight에 따라서 동적으로 itemsPerPage를 설정

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/a614bce5-848e-4f3b-824f-92e95f7b4350)
![image](https://github.com/user-attachments/assets/46db6153-322c-4508-908c-a9d7404e1d85)
![image](https://github.com/user-attachments/assets/49dfde60-45cb-4882-9314-5df2f5615b95)

## 💬 리뷰 요구사항(선택)
페이지네이션 UI와 현재 페이지네이션 밑에 약간의 공백이 있습니다. 윈도우창이 일정 Height값보다 작아지면 페이지네이션이 보이지 않게 되어서 50 정도 window.innerHeight에서 빼놓은 상태입니다. 뭐가 더 나을 것 같은지 체크 부탁드립니다.


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
