### PR TITLE
Design: 다중 코호트 통계 페이지 레이아웃 변경

### DIFF
--- a/frontend/src/lib/components/ChartCard.svelte
+++ b/frontend/src/lib/components/ChartCard.svelte
@@ -36,8 +36,8 @@
 	class:col-span-1={type === 'half'}>
 
 	<!-- 헤더 영역 -->
-	<div class="flex items-center gap-3">
-		<span class="text-lg font-semibold">{title}</span>
+	<div class="flex items-center gap-2">
+		<span class="text-base font-semibold">{title}</span>
 		<div class="group relative">
 			<span class="text-sm text-gray-400 cursor-pointer">ⓘ</span>
 			<div class="absolute bottom-full mb-2 left-0 w-48 bg-gray-700 text-white text-xs rounded-md px-2 py-1 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
@@ -48,7 +48,7 @@
 		{#if showSelector && options.length > 0}
 			<div class="relative inline-block">
 				<button 
-					class="text-sm font-medium text-gray-700 hover:text-blue-600 flex items-center gap-2 min-w-[150px]"
+					class="text-xs font-medium text-gray-700 hover:text-blue-600 flex items-center gap-2 min-w-[150px]"
 					on:click|stopPropagation={() => isDropdownOpen = !isDropdownOpen}>
 					<span class="truncate">{options.find(opt => opt.id === selectedOption)?.name || 'Select'}</span>
 					<svg class="w-4 h-4 text-current flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
@@ -61,7 +61,7 @@
 						class="absolute z-10 left-0 mt-1 bg-white border border-gray-200 rounded-md shadow-lg py-1 min-w-[200px]">
 						{#each options as option}
 							<button
-								class="w-full px-4 py-2 text-sm text-left hover:bg-gray-100 
+								class="w-full px-4 py-2 text-xs text-left hover:bg-gray-100 
 										{selectedOption === option.id ? 'text-blue-600 font-medium' : 'text-gray-700'}"
 								on:click|stopPropagation={() => handleSelect(option.id)}>
 								{option.name}

--- a/frontend/src/lib/components/ChartCard.svelte
+++ b/frontend/src/lib/components/ChartCard.svelte
@@ -31,9 +31,9 @@
 
 {#if visible}
 <div 
-	class="bg-white border border-gray-300 rounded-lg shadow-md p-6 h-[350px] relative mb-1 w-full"
-	class:col-span-2={type === 'full'}
-	class:col-span-1={type === 'half'}>
+	class="bg-white border border-gray-300 rounded-lg shadow-md p-6 h-[300px] relative mb-1 w-full"
+	class:col-span-4={type === 'full'}
+	class:col-span-2={type === 'half'}>
 
 	<!-- 헤더 영역 -->
 	<div class="flex items-center gap-2">

--- a/frontend/src/lib/components/Charts/DonutChart/GroupDonutChartWrapper.svelte
+++ b/frontend/src/lib/components/Charts/DonutChart/GroupDonutChartWrapper.svelte
@@ -25,20 +25,22 @@
     })) || [];
 </script>
 
-<div class="flex flex-col items-center justify-center">
-    <div class="flex flex-row justify-center items-start gap-8">
-        {#each processedData as chart}
-            <div class="flex flex-col items-center">
-                <DonutChart 
-                    data={chart.data}
-                    {hoveredLabel}
-                    {colorScale}
-                    width={200}
-                    height={200}
-                />
-                <span class="text-sm font-medium text-gray-600">{chart.name}</span>
-            </div>
-        {/each}
+<div class="flex flex-col items-center justify-center w-full">
+    <div class="w-full overflow-x-auto">
+        <div class="flex flex-row justify-center items-start gap-2 px-4" style="min-width: 600px">
+            {#each processedData as chart}
+                <div class="flex flex-col items-center w-[200px]">
+                    <DonutChart 
+                        data={chart.data}
+                        {hoveredLabel}
+                        {colorScale}
+                        width={150}
+                        height={150}
+                    />
+                    <span class="text-sm font-medium text-gray-600">{chart.name}</span>
+                </div>
+            {/each}
+        </div>
     </div>
     {#if processedData.length > 0}
         <div class="mt-4">

--- a/frontend/src/lib/components/Charts/LineChart/LineChart.svelte
+++ b/frontend/src/lib/components/Charts/LineChart/LineChart.svelte
@@ -1,32 +1,64 @@
 <script>
-    import { onMount, onDestroy } from "svelte";
+    import { onMount, onDestroy, tick } from "svelte";
     import { browser } from "$app/environment";
     import * as d3 from "d3";
-  
+
     export let data = [];
-    export let cohortColorMap;
-    let margin = { top: 30, right: 120, bottom: 50, left: 50 };  // 오른쪽 여백 증가
+    export let cohortColorMap = {};
+    export let showLegend = true;
+
+    const margin = { top: 30, right: 120, bottom: 50, left: 50 };
     let chartContainer;
     let width;
     let height;
+    let resizeObserver;
+    let visibleSeries;
+    let tooltip;
 
-    $: uniqueSeries = [...new Set(data.map(d => d.series))];
-    $: visibleSeries = new Set(uniqueSeries);
-    $: showLegend = uniqueSeries.length > 1;
-    $: effectiveMargin = { ...margin };
-    $: if (!showLegend) {
-        effectiveMargin.right = 30;
+    // cohortColorMap이 변경될 때마다 visibleSeries 업데이트
+    $: {
+        visibleSeries = new Set(Object.keys(cohortColorMap));
     }
 
-
-    function handleResize(){
-        if(chartContainer){
+    function handleResize() {
+        if (chartContainer) {
             const containerRect = chartContainer.getBoundingClientRect();
             width = containerRect.width;
             height = containerRect.height;
+            drawChart();
         }
     }
-    
+
+    async function initializeChart() {
+        if (browser && chartContainer) {
+            // 툴팁 초기화
+            tooltip = d3.select("body")
+                .append("div")
+                .attr("class", "tooltip")
+                .style("position", "absolute")
+                .style("background", "white")
+                .style("border", "1px solid #eee")
+                .style("border-radius", "4px")
+                .style("padding", "0")
+                .style("display", "none")
+                .style("pointer-events", "none")
+                .style("z-index", "100")
+                .style("box-shadow", "0 2px 4px rgba(0,0,0,0.05)")
+                .style("backdrop-filter", "blur-sm");
+
+            resizeObserver = new ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    if (entry.target === chartContainer) {
+                        handleResize();
+                    }
+                }
+            });
+            resizeObserver.observe(chartContainer);
+            await tick();
+            handleResize();
+        }
+    }
+
     // 시리즈 토글 함수
     function toggleSeries(series) {
         if (visibleSeries.has(series)) {
@@ -35,54 +67,26 @@
             visibleSeries.add(series);
         }
         visibleSeries = visibleSeries; // Svelte 반응성 트리거
-        updateChart(); // 차트 업데이트 함수 호출
+        drawChart();
     }
 
-    // 차트 업데이트 함수
-    function updateChart() {
-        if (!chartContainer || !data || data.length === 0) return;
-
-        const svg = d3.select(chartContainer).select("svg");
-        
-        // 기존 차트 요소들 업데이트
-        seriesData.forEach(([key, values]) => {
-            // 선 업데이트
-            svg.select(`path.line-${key}`)
-                .style("opacity", visibleSeries.has(key) ? 1 : 0);
-
-            // 점 업데이트
-            svg.selectAll(`.point-${key}`)
-                .style("opacity", visibleSeries.has(key) ? 1 : 0);
-        });
-    }
-
-    onMount(() => {
-        if(browser){
-            window.addEventListener('resize', handleResize);
-        }
-    });
-
-    onDestroy(() => {
-        if(browser){
-            window.removeEventListener('resize', handleResize);
-        }
-    });
-
-    $: if(chartContainer && data && data.length > 0) {
-        handleResize();
+    function drawChart() {
+        if (!chartContainer || !width || !height || !data || data.length === 0) return;
 
         const svg = d3
             .select(chartContainer)
             .html("") // 기존 SVG 초기화
             .append("svg")
-            .attr("width", width)
-            .attr("height", height);
+            .attr("width", "100%")
+            .attr("height", "100%")
+            .attr("viewBox", `0 0 ${width} ${height}`)
+            .attr("preserveAspectRatio", "xMidYMid meet");
 
-            // 스케일 설정
+        // 스케일 설정
         const x = d3
             .scaleBand()
             .domain(data.map(d => d.label))
-            .range([effectiveMargin.left, width - effectiveMargin.right])
+            .range([margin.left, width - margin.right])
             .padding(0.1);
     
         const y = d3
@@ -96,7 +100,7 @@
         const yAxis = d3.axisLeft(y);
     
         svg.append("g")
-            .attr("transform", `translate(0,${height - effectiveMargin.bottom})`)
+            .attr("transform", `translate(0,${height - margin.bottom})`)
             .call(xAxis)
             .selectAll("text")
             .style("text-anchor", "end")
@@ -106,7 +110,7 @@
             .attr("stroke", d => cohortColorMap[d]); 
     
         svg.append("g")
-            .attr("transform", `translate(${effectiveMargin.left},0)`)
+            .attr("transform", `translate(${margin.left},0)`)
             .call(yAxis);
   
         // 선 생성
@@ -116,109 +120,123 @@
             .y(d => y(d.value));
     
         const seriesData = d3.groups(data, d => d.series);
-    
-        seriesData.forEach(([key, values]) => {
-            if (!visibleSeries.has(key)) return; // 숨겨진 시리즈는 건너뛰기
+
+        // 선 그리기
+        seriesData.forEach(([series, values]) => {
+            const isVisible = visibleSeries.has(series);
+            const opacity = isVisible ? 1 : 0.2;
 
             // 선 그리기
-            svg
-            .append("path")
-            .datum(values)
-            .attr("fill", "none")
-            .attr("stroke-width", 2)
-            .attr("stroke", cohortColorMap[key])
-            .attr("d", line(values))
-            .attr("class", `line-${key}`)
-            .attr("opacity", visibleSeries.has(key) ? 1 : 0);
-  
-            // 데이터 포인트 (원) 그리기
-            svg
-            .selectAll(`.point-${key}`)
-            .data(values)
-            .enter()
-            .append("circle")
-            .attr("cx", d => x(d.label) + x.bandwidth() / 2)
-            .attr("cy", d => y(d.value))
-            .attr("r", 4)
-            .attr("fill", cohortColorMap[key])
-            .attr("stroke", "white")
-            .attr("opacity", visibleSeries.has(key) ? 1 : 0)
-            .on("mouseover", function (event, d) {
-                tooltip
-                .style("display", "block")
-                .style("left", (event.pageX + 10) + "px")
-                .style("top", (event.pageY - 10) + "px")
-                .html(`
-                    <div class="p-1">
-                    <div class="text-[10px] font-semibold mb-0.5">${d.series}</div>
-                    <div class="text-[9px] text-gray-600">
-                        ${d.label}:
-                        <span class="ml-0.5 font-medium text-black">${d.value.toLocaleString()}</span>
-                    </div>
-                    </div>
-                `);
-            })
-            .on("mouseout", function () {
-                tooltip.style("display", "none");
-            });
-      });
-  
-      // 범례 그리기
-    if(showLegend){
-        const legend = svg.append("g")
-            .attr("font-family", "sans-serif")
-            .attr("font-size", 10)
-            .attr("text-anchor", "start")
-            .selectAll("g")
-            .data(seriesData)
-            .join("g")
-            .attr("transform", (d, i) => `translate(${width - margin.right + 10},${margin.top + i * 20})`);
-  
-        // 범례 색상 표시 및 체크박스
-        legend.append("rect")
-            .attr("x", 0)
-            .attr("width", 12)
-            .attr("height", 12)
-            .attr("fill", d => cohortColorMap[d[0]])
-            .attr("stroke", d => cohortColorMap[d[0]])
-            .attr("cursor", "pointer")
-            .on("click", (event, d) => toggleSeries(d[0]));
-    
-        // 체크마크
-        legend.append("path")
-            .attr("d", "M2 6l3 3 5-5")
-            .attr("stroke", "white")
-            .attr("stroke-width", 1.5)
-            .attr("fill", "none")
-            .style("opacity", d => visibleSeries.has(d[0]) ? 1 : 0);
-    
-        // 범례 텍스트
-        legend.append("text")
-            .attr("x", 20)
-            .attr("y", 9.5)
-            .attr("dy", "0.02em")
-            .text(d => d[0])
-            .style("opacity", d => visibleSeries.has(d[0]) ? 1 : 0.5)
-            .style("cursor", "pointer")
-            .on("click", (event, d) => toggleSeries(d[0])); // 텍스트 클릭으로도 토글 가능하게
-      }
-      
-    // 툴팁 설정
-    const tooltip = d3
-        .select("body")
-        .append("div")
-        .style("position", "absolute")
-        .style("background", "white")
-        .style("border", "1px solid #eee")
-        .style("border-radius", "4px")
-        .style("padding", "0")
-        .style("display", "none")
-        .style("pointer-events", "none")
-        .style("z-index", "100")
-        .style("box-shadow", "0 2px 4px rgba(0,0,0,0.05)")
-        .style("backdrop-filter", "blur-sm");
+            svg.append("path")
+                .datum(values)
+                .attr("fill", "none")
+                .attr("stroke", cohortColorMap[series])
+                .attr("stroke-width", 2)
+                .attr("d", line)
+                .attr("class", `line-${series}`)
+                .style("opacity", opacity);
+            
+            // 점 그리기
+            svg.selectAll(`circle-${series}`)
+                .data(values)
+                .join("circle")
+                .attr("cx", d => x(d.label) + x.bandwidth() / 2)
+                .attr("cy", d => y(d.value))
+                .attr("r", 4)
+                .attr("fill", cohortColorMap[series])
+                .attr("stroke", "white")
+                .attr("stroke-width", 2)
+                .attr("class", `point-${series}`)
+                .style("opacity", opacity)
+                .on("mouseover", function(event, d) {
+                    d3.select(this)
+                        .transition()
+                        .duration(200)
+                        .attr("r", 6);
+
+                    tooltip
+                        .style("display", "block")
+                        .style("left", (event.pageX + 10) + "px")
+                        .style("top", (event.pageY - 10) + "px")
+                        .html(`
+                            <div class="p-1">
+                                <div class="text-[10px] font-semibold mb-0.5">${series}</div>
+                                <div class="text-[9px] text-gray-600">
+                                    ${d.label}:
+                                    <span class="ml-0.5 font-medium text-black">${d.value.toLocaleString()}</span>
+                                </div>
+                            </div>
+                        `);
+                })
+                .on("mouseout", function() {
+                    d3.select(this)
+                        .transition()
+                        .duration(200)
+                        .attr("r", 4);
+                    
+                    tooltip.style("display", "none");
+                });
+        });
+
+        // 범례 그리기
+        if (showLegend) {
+            const legend = svg.append("g")
+                .attr("font-family", "sans-serif")
+                .attr("font-size", 10)
+                .attr("text-anchor", "start")
+                .selectAll("g")
+                .data(seriesData)
+                .join("g")
+                .attr("transform", (d, i) => `translate(${width - margin.right + 10},${margin.top + i * 20})`);
+
+            // 범례 색상 표시 및 체크박스
+            legend.append("rect")
+                .attr("x", 0)
+                .attr("width", 12)
+                .attr("height", 12)
+                .attr("fill", d => cohortColorMap[d[0]])
+                .attr("stroke", d => cohortColorMap[d[0]])
+                .attr("cursor", "pointer")
+                .style("opacity", d => visibleSeries.has(d[0]) ? 1 : 0.2)
+                .on("click", (event, d) => toggleSeries(d[0]));
+
+            // 체크마크
+            legend.append("path")
+                .attr("d", "M2 6l3 3 5-5")
+                .attr("stroke", "white")
+                .attr("stroke-width", 1.5)
+                .attr("fill", "none")
+                .style("opacity", d => visibleSeries.has(d[0]) ? 1 : 0);
+
+            // 범례 텍스트
+            legend.append("text")
+                .attr("x", 20)
+                .attr("y", 9.5)
+                .attr("dy", "0.02em")
+                .text(d => d[0])
+                .style("opacity", d => visibleSeries.has(d[0]) ? 1 : 0.5)
+                .style("cursor", "pointer")
+                .on("click", (event, d) => toggleSeries(d[0]));
+        }
     }
-  
+
+    onMount(() => {
+        initializeChart();
+    });
+
+    onDestroy(() => {
+        if (browser && resizeObserver) {
+            resizeObserver.disconnect();
+        }
+        // 툴팁 제거
+        if (tooltip) {
+            tooltip.remove();
+        }
+    });
+
+    $: if (data && data.length > 0 && width && height) {
+        drawChart();
+    }
 </script>
 
-<div bind:this={chartContainer} class="w-full h-full"></div>
+<div bind:this={chartContainer} class="w-full h-full [&>svg]:max-w-full [&>svg]:h-auto"></div>

--- a/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChart.svelte
+++ b/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChart.svelte
@@ -111,7 +111,7 @@
             drawChart();
             window.addEventListener('resize', handleResize);
             resizeObserver = new ResizeObserver(() => {
-            handleResize();
+                handleResize();
             });
             resizeObserver.observe(chartContainer);
         }

--- a/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChart.svelte
+++ b/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChart.svelte
@@ -15,6 +15,7 @@
     let width;
     let height;
     const margin = { top: 30, right: 80, bottom: 10, left: 140 };
+    let resizeObserver;
 
     // 데이터나 크기가 변경될 때마다 차트 다시 그리기
     $: if (chartContainer && stackData.length > 0 && width && height) {
@@ -109,6 +110,10 @@
             await tick();
             drawChart();
             window.addEventListener('resize', handleResize);
+            resizeObserver = new ResizeObserver(() => {
+            handleResize();
+            });
+            resizeObserver.observe(chartContainer);
         }
     });
 
@@ -116,6 +121,10 @@
         if (browser) {
             window.removeEventListener('resize', handleResize);
         }
+        if (resizeObserver && chartContainer) {
+            resizeObserver.unobserve(chartContainer);
+        }
+
     });
     
 </script>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -163,7 +163,7 @@
 		{/if}
 	</header>
 
-	<main class="absolute top-[60px] w-full h-[calc(100vh-60px)] overflow-x-auto overflow-y-auto pt-8">
+	<main class="absolute top-[30px] w-full min-h-[calc(100vh-60px)] overflow-x-auto overflow-y-auto pt-8">
 		{@render children()}
 	</main>
 </div>

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -504,7 +504,7 @@
         <!-- Select Chart 드롭다운 -->
         <div class="relative" bind:this={selectChartRef}>
           <button 
-            class="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+            class="px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
             on:click|stopPropagation={toggleSelectChart}
           >
             <span>{isSelectChartOpen ? '▲' : '▼'} Select Chart</span>
@@ -521,7 +521,7 @@
                       on:change={() => handleCheckboxChange(item)}
                       class="w-4 h-4 text-blue-600 rounded border-gray-300"
                     />
-                    <span class="text-sm text-gray-700">{item.name}</span>
+                    <span class="text-xs text-gray-700">{item.name}</span>
                   </label>
                 {/each}
               </div>

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -395,11 +395,11 @@
 
 <div class="flex h-[calc(100vh-60px)] bg-gray-50">
   <!-- 좌측 사이드바 -->
-  <div class="bg-white border-r border-gray-200 flex flex-col h-full sidebar-transition {isSidebarCollapsed ? 'w-[40px]' : 'w-[320px]'}">
+  <div class="bg-white border-r border-gray-200 flex flex-col h-full sidebar-transition {isSidebarCollapsed ? 'w-[40px]' : 'w-[250px]'}">
     <div class="pl-4 pr-4 pt-4 flex items-center justify-between flex-shrink-0">
       {#if !isSidebarCollapsed}
         <div class="flex items-center justify-between w-full">
-          <h3 class="text-lg font-bold">Selected Cohorts</h3>
+          <h3 class="text-lg font-semibold">Selected Cohorts</h3>
           <button aria-label="Toggle Sidebar"
             class="p-1 hover:bg-gray-100 rounded-md transition-colors"
             on:click={toggleSidebar}
@@ -442,7 +442,7 @@
                 class="w-full flex items-center justify-between p-2 hover:bg-gray-50 transition-colors"
                 on:click={() => toggleExpand(index)}
               >
-                <div class="flex items-center gap-2 flex-1 min-w-0">
+                <div class="flex items-start gap-2 flex-1 min-w-0">
                   <svg 
                     class="w-3 h-3 flex-shrink-0 transform transition-transform {expandedStates[index] ? 'rotate-180' : ''}" 
                     fill="none" 
@@ -454,8 +454,9 @@
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-1">
                       <span class="text-[10px] font-medium text-gray-400 truncate">{cohort.id}</span>
-                      <div class="text-xs font-medium text-blue-600 truncate">{cohort.name}</div>
-                      <span class="bg-blue-100 text-blue-800 px-1.5 py-px rounded-full text-[10px]">{cohort.totalPatients}</span>
+                    </div>
+                    <div class="flex items-center gap-1">
+                    <div class="text-xs font-medium text-blue-600 break-words whitespace-normal">{cohort.name}</div>
                     </div>
                     <div class="flex items-center gap-1 mt-0.5">
                     </div>
@@ -469,6 +470,10 @@
                     <div>
                       <span class="text-gray-500">Author:</span>
                       <span class="font-regular">{cohort.author}</span>
+                    </div>
+                    <div>
+                      <span class="text-gray-500">Total Patients:</span>
+                      <span class="font-regular">{cohort.totalPatients}</span>
                     </div>
                     <div>
                       <span class="text-gray-500">Description:</span>

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -539,7 +539,7 @@
             title="Gender Ratio" 
             description="The ratio of genders within the cohort."
             chartId={0}
-            type="full"
+            type={selectedCohorts.length <= 3 ? 'half' : 'full'}
             hasTableView={true}
             isTableView={isTableView.genderRatio}
             on:toggleView={({detail}) => isTableView.genderRatio = detail}
@@ -568,7 +568,7 @@
             title="Mortality" 
             description="The percentage of patients within the cohort who have died."
             chartId={1}
-            type="full"
+            type={selectedCohorts.length <= 3 ? 'half' : 'full'}
             hasTableView={true}
             isTableView={isTableView.mortality}
             on:toggleView={({detail}) => isTableView.mortality = detail}
@@ -597,7 +597,7 @@
             title="Visit Type Ratio"
             description="The proportion of different types of medical visits (outpatient, inpatient, emergency room, etc.) that occurred during the cohort period."
             chartId={2}
-            type="full"
+            type={selectedCohorts.length <= 3 ? 'half' : 'full'}
             hasTableView={true}
             isTableView={isTableView.visitTypeRatio}
             on:toggleView={({detail}) => isTableView.visitTypeRatio = detail}

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -342,7 +342,7 @@
   function getViewOptions(domainKey) {
     // 기본 Combined View 옵션
     const options = [
-      { id: 'combined', name: 'Combined Cohorts View' }
+      { id: 'combined', name: 'Combined View' }
     ];
     
     // 각 코호트별 Anchor View 옵션 추가

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -528,7 +528,7 @@
 
     <!-- 차트 그리드 -->
     <div class="flex-1 overflow-y-auto p-6">
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {#if selectItems[0].checked}
           <ChartCard 
             title="Gender Ratio" 


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#58 

## 📝 작업 내용
다중 코호트 통계 페이지의 레이아웃을 변경하고 리팩토링하였습니다. 여러 정보가 한눈에 들어올 수 있도록 선택한 코호트를 사이드바로 분류하였고, 전체적으로 크기를 축소시켰습니다.

### 스크린샷 (선택)
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/0adc3cc8-e681-4592-af2b-4be7306ffb3d" />
<img width="1248" alt="image" src="https://github.com/user-attachments/assets/89a389ca-e312-4908-93b6-700907524762" />


## 💬 리뷰 요구사항(선택)
변경한 레이아웃 디자인이 괜찮은지 봐주시면 감사하겠습니다.