### PR TITLE
Fix: 테이블 뷰에서 앵커 코호트 전환 안되는 버그 해결

### DIFF
--- a/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChartTableView.svelte
+++ b/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChartTableView.svelte
@@ -5,26 +5,25 @@
     export let domainKey;
     export let orderedCohorts = [];
     export let cohortTotalCounts = {};
-    
-    const headers = [
+
+    $: headers = [
         "No.",
         domainKey.charAt(0).toUpperCase() + domainKey.slice(1),
         ...orderedCohorts
     ];
     
-    console.log(headers);
-    const rows = data.map((item, index) => {
+    $: rows = data.map((item, index) => {
         const row = {
-        "No.": index + 1,
-        [headers[1]]: item[domainKey]
+            "No.": index + 1,
+            [headers[1]]: item[domainKey]
         };
 
         orderedCohorts.forEach(cohort => {
-        const value = +item[cohort];
-        const total = +cohortTotalCounts[cohort];
-        row[cohort] = total ?
-            `${value.toLocaleString()} (${((value / total) * 100).toFixed(2)}%)` :
-            value.toLocaleString();
+            const value = +item[cohort];
+            const total = +cohortTotalCounts[cohort];
+            row[cohort] = total ?
+                `${value.toLocaleString()} (${((value / total) * 100).toFixed(2)}%)` :
+                value.toLocaleString();
         });
 
         return row;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#63 

## 📝 작업 내용
테이블의 header, row 계산에 반응성을 추가하여 테이블이 전환되도록 하였습니다. 

## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
