### PR TITLE
Feat: pdf to cohort 새 규격에 맞춤

### DIFF
--- a/ai/cohort_json_schema.py
+++ b/ai/cohort_json_schema.py
@@ -1,816 +1,613 @@
+JSON_INPUT_EXAMPLE = """
+Input Text Example:
+3.1. Inclusion criteria  
+Patients who are 20 years old or older.
+Patients with hemodialysis.
+Patients using ESA therapy for at least three months.
+Patients with iron deficiency anemia.
+
+3.2. Exclusion criteria  
+Patients in intensive care unit.  
+Patients with hemoglobin value more than 13 g/dL.  
+Kidney transplant patients.  
+Patients with sepsis or active infections.
+"""
+
 JSON_OUTPUT_EXAMPLE = """
-{
-  "PrimaryCriteria": {
-    "CriteriaList": [
-      {
-        "CriteriaType": "ProcedureOccurrence",
-        "ConceptName": "hemodialysis",
-        "ProcedureOccurrence": {}
-      }
-    ],
-    "PrimaryCriteriaLimit": {
-      "Type": 0,
-      "Count": 1
+다음은 주어진 임상시험 텍스트를 바탕으로 OMOP CDM 규격에 맞게 구성된 최종 JSON 예시입니다:
+
+const cohortExample: CohortDefinition = {
+  conceptsets: [
+    {
+      conceptset_id: "0",
+      name: "Hemodialysis",
+      type: "ProcedureOccurrence",
+      items: [
+        {
+          concept_id: "101",
+          concept_name: "Hemodialysis",
+          domain_id: "Procedure",
+          vocabulary_id: "OMOP",
+          concept_class_id: "Procedure",
+          standard_concept: "S",
+          concept_code: "HD01",
+          valid_start_date: "2000-01-01",
+          valid_end_date: "2099-12-31",
+          invalid_reason: ""
+        },
+        {
+          concept_id: "102",
+          concept_name: "Hemodialysis2",
+          domain_id: "Procedure",
+          vocabulary_id: "OMOP",
+          concept_class_id: "Procedure",
+          standard_concept: "S",
+          concept_code: "HD02",
+          valid_start_date: "2000-01-01",
+          valid_end_date: "2099-12-31",
+          invalid_reason: ""
+        }
+      ]
     }
-  },
-  "AdditionalCriteria": {
-    "Type": "ALL",
-    "CriteriaList": [],
-    "DemographicCriteriaList": [],
-    "Groups": [
-      {
-        "Type": "ALL",
-        "CriteriaList": [
-          {
-            "Criteria": {
-              "CriteriaType": "ObservationPeriod",
-              "AgeAtStart": {
-                "Value": 18,
-                "Op": "gte"
-              },
-              "ObservationPeriod": {}
+    // 추가 conceptset 항목이 있으면 여기에 추가합니다.
+  ],
+  cohort: [
+    {
+      // Group 1: Inclusion Criteria
+      containers: [
+        {
+          name: "hemodialysis",
+          filters: [
+            {
+              type: "procedure_occurrence",
+              first: true,
+              conceptset: "0",
+              age: { gte: 20 }
             }
-          },
-          {
-            "Criteria": {
-              "CriteriaType": "DrugExposure",
-              "ConceptName": "erythropoiesis stimulating agent",
-              "DrugExposure": {}
+          ]
+        },
+        {
+          operator: "AND",
+          name: "ESA therapy",
+          filters: [
+            {
+              type: "drug_exposure",
+              first: true,
+              conceptset: "1"
             }
-          },
-          {
-            "Criteria": {
-              "CriteriaType": "ConditionOccurrence",
-              "ConceptName": "iron deficiency anemia",
-              "ConditionOccurrence": {}
+          ]
+        },
+        {
+          operator: "AND",
+          name: "iron deficiency anemia",
+          filters: [
+            {
+              type: "condition_era",
+              first: true,
+              conceptset: "2"
             }
-          }
-        ],
-        "DemographicCriteriaList": [],
-        "Groups": []
-      },
-      {
-        "Type": "NONE",
-        "CriteriaList": [
-          {
-            "Criteria": {
-              "CriteriaType": "VisitOccurrence",
-              "ConceptName": "intensive care unit",
-              "VisitOccurrence": {}
+          ]
+        }
+      ]
+    },
+    {
+      // Group 2: Exclusion Criteria
+      not: true,
+      containers: [
+        {
+          name: "intensive care unit",
+          filters: [
+            {
+              type: "observation",
+              first: true,
+              conceptset: "3"
             }
-          },
-          {
-            "Criteria": {
-              "CriteriaType": "Measurement",
-              "ConceptName": "hemoglobin",
-              "Measurement": {},
-              "ValueAsNumber": {
-                "Value": 13,
-                "Op": "gt"
-              }
+          ]
+        },
+        {
+          operator: "AND",
+          name: "hemoglobin > 13 g/dL",
+          filters: [
+            {
+              type: "measurement",
+              first: true,
+              measurementType: { eq: "234567" },
+              valueAsNumber: { gt: 13 },
+              conceptset: "4"
             }
-          },
-          {
-            "Criteria": {
-              "CriteriaType": "ProcedureOccurrence",
-              "ConceptName": "kidney transplant",
-              "ProcedureOccurrence": {}
+          ]
+        },
+        {
+          operator: "AND",
+          name: "kidney transplant",
+          filters: [
+            {
+              type: "procedure_occurrence",
+              first: true,
+              conceptset: "5"
             }
-          },
-          {
-            "Criteria": {
-              "CriteriaType": "ConditionOccurrence",
-              "ConceptName": "sepsis",
-              "ConditionOccurrence": {}
+          ]
+        },
+        {
+          operator: "AND",
+          name: "sepsis or active infections",
+          filters: [
+            {
+              type: "condition_era",
+              first: true,
+              conceptset: "6"
             }
-          }
-        ],
-        "DemographicCriteriaList": [],
-        "Groups": []
-      }
-    ]
-  },
-  "ConceptSets": [],
-  "EndStrategy": {
-    "DateField": "EndDate",
-    "Offset": 0
-  },
-  "cdmVersionRange": ">=5.0.0",
-  "includeAllDescendants": true,
-  "includedCovariateConceptIds": [],
-  "CensoringCriteria": [],
-  "InclusionRules": [],
-  "CollapseSettings": {
-    "CollapseType": "ERA",
-    "EraPad": 0
-  }
-}
+          ]
+        }
+      ]
+    }
+  ]
+};
+
 """
 
 JSON_SCHEMA = """
 The following is the required JSON format to be returned.
-/*******************************************************************************
- * Copyright 2025 Observational Health Data Sciences and Informatics
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *   http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+/**
+ * 특정 값을 필터링하기 위한 일반적인 비교 연산자를 나타냅니다.
  *
- * Authors: Christopher Knoll, Gowtham Rao
- ******************************************************************************/
-
-import { ConceptSet } from './ConceptSet';
-
-export enum CollapseType {
-  ERA = "ERA",
-  NONE = "NONE"
+ * - `Operator<T>` 내의 모든 조건은 AND 로직으로 결합됩니다.
+ *   예시:
+ *   `{ gt: 1, lt: 3 }` → `(VALUE > 1 AND VALUE < 3)`
+ *
+ * - 특정 조건에 배열(`T[]`)이 제공되면, OR 조건으로 처리됩니다.
+ *   예시:
+ *   `{ gt: [1, 5] }` → `(VALUE > 1 OR VALUE > 5)`
+ */
+export interface Operator<T> {
+  neq?: T | T[];
+  eq?: T | T[];
+  gt?: T | T[];
+  gte?: T | T[];
+  lt?: T | T[];
+  lte?: T | T[];
 }
 
-export class CollapseSettings {
-  EraPad: number = 0;
-  CollapseType: CollapseType = CollapseType.ERA;
+/**
+ * 문자열을 대상으로 하는 필터링 연산을 나타냅니다.
+ *
+ * - `StringOperator` 내의 조건들은 AND 로직으로 결합됩니다.
+ * - 배열이 주어진 조건은 OR 조건으로 처리됩니다.
+ *
+ * 예시:
+ * `{ startsWith: ["a", "b"], endsWith: ["c", "d"] }`
+ * → `((VALUE LIKE "a%" OR VALUE LIKE "b%") AND (VALUE LIKE "%c" OR VALUE LIKE "%d"))`
+ */
+export interface StringOperator {
+  neq?: string | string[];
+  eq?: string | string[];
+  startsWith?: string | string[];
+  endsWith?: string | string[];
+  contains?: string | string[];
 }
 
-export class NumericRange {
-  Value: number = 0;
-  Op: string = "gt";
-  Extent?: number;
-  // Add these for compatibility with Window.Endpoint
-  Days?: number;
-  Coeff?: number;
+export type Identifier = string;
+
+export interface IdentifierOperator {
+  neq?: Identifier | Identifier[];
+  eq?: Identifier | Identifier[];
 }
 
-export class TextFilter {
-  Text: string = "";
-  Op: string = "contains";
+/**
+ * 숫자(정수/실수) 관련 연산자를 나타냅니다.
+ */
+export type NumberWithOperator = number | Operator<number>;
+
+/**
+ * 식별자(string) 관련 연산자를 나타냅니다.
+ */
+export type IdentifierWithOperator = Identifier | IdentifierOperator;
+
+/**
+ * 날짜(문자열) 관련 연산자를 나타냅니다.
+ */
+export type DateWithOperator = string | Operator<string>;
+
+/**
+ * 문자열 관련 연산자를 나타냅니다.
+ */
+export type StringWithOperator = string | StringOperator;
+
+export interface BaseContainer {
+  name: string;
+  filters: Filter[];
 }
 
-export class Period {
-  StartDate: Date = new Date();
-  EndDate: Date = new Date();
+export interface FirstContainer extends BaseContainer {}
+
+export interface SubsequentContainer extends BaseContainer {
+  operator: "AND" | "OR" | "NOT";
 }
 
-export class DateRange {
-  StartDate?: Date;
-  EndDate?: Date;
-  
-  // Add these for compatibility with old code
-  Value?: string | Date;
-  Extent?: string | Date;
-  Op?: string;
+export interface BaseGroup {
+  containers: [FirstContainer, ...SubsequentContainer[]];
 }
 
-export class Window {
-  Start: NumericRange | null = null;
-  End: NumericRange | null = null;
-  UseIndexEnd: boolean = false;
-  UseEventEnd: boolean = false;
-  // Properties for ObservationFilter compatibility
-  ObservationTypeExclude?: boolean = false;
-  ObservationType?: number[] = [];
-  // Properties to bridge namespace usage
-  PriorDays?: number;
-  PostDays?: number;
+export interface FirstGroup extends BaseGroup {
+  mergeByPersonId?: boolean;
 }
 
-export class DateOffsetStrategy {
-  DateField: string = "";
-  Offset: number = 0;
+export interface SubsequentGroup extends BaseGroup {
+  not: boolean | undefined | null;
 }
 
-export class DateAdjustment {
-  StartOffset: number = 0;
-  EndOffset: number = 0;
+export type Cohort = [FirstGroup, ...SubsequentGroup[]];
+
+export type Concept = {
+  concept_id: Identifier;
+  concept_name: string;
+  domain_id: string;
+  vocabulary_id: string;
+  concept_class_id: string;
+  standard_concept: string;
+  concept_code: string;
+  valid_start_date: string;
+  valid_end_date: string;
+  invalid_reason: string;
+
+  isExcluded?: boolean;
+  includeDescendants?: boolean;
+  includeMapped?: boolean;
+};
+
+export interface ConceptSet {
+  id: Identifier;
+  name: string;
+  items: Concept[];
 }
 
-export class EndStrategy {
-  DateField?: string;
-  Offset?: number;
+export interface CohortDefinition {
+  conceptsets?: ConceptSet[];
+  cohort: Cohort;
 }
 
-export class CustomEraStrategy extends EndStrategy {
-  DrugCodesetId: number = 0;
-  GapDays: number = 0;
-  Offset: number = 0;
+/**
+ * 도메인 타입에 따른 필터 맵핑입니다.
+ */
+export type FilterMap = {
+  condition_era: ConditionEraFilter;
+  condition_occurrence: ConditionOccurrenceFilter;
+  death: DeathFilter;
+  device_exposure: DeviceExposureFilter;
+  dose_era: DoseEraFilter;
+  drug_era: DrugEraFilter;
+  drug_exposure: DrugExposureFilter;
+  measurement: MeasurementFilter;
+  observation: ObservationFilter;
+  observation_period: ObservationPeriodFilter;
+  procedure_occurrence: ProcedureOccurrenceFilter;
+  specimen: SpecimenFilter;
+  visit_occurrence: VisitOccurrenceFilter;
+  demographic: DemographicFilter;
+};
+
+/**
+ * 각 도메인 타입을 FilterMap의 키 값으로부터 추출합니다.
+ */
+export type DomainType = keyof FilterMap;
+
+/**
+ * 모든 가능한 필터 타입을 정의합니다.
+ */
+export type Filter = {
+  [K in DomainType]: { type: K } & FilterMap[K];
+}[DomainType];
+
+/**
+ * condition_era 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface ConditionEraFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  startAge?: NumberWithOperator;
+  endAge?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  conditionCount?: NumberWithOperator;
+  length?: NumberWithOperator;
 }
 
-export class ConceptSetSelection {
-  Min: number = 1;
-  Max: number = 1;
-  CodesetId?: number;
+/**
+ * condition_occurrence 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface ConditionOccurrenceFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  conditionStatus?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  conditionType?: IdentifierWithOperator;
+  visitType?: IdentifierWithOperator;
+  //stopReason?: StringWithOperator;
+  source?: IdentifierWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
 }
 
-export class Occurrence {
-  Type: number = 0;  // 0: exactly, 1: at least, 2: at most
-  Count: number = 0;
-  IsDistinct: boolean = false;
+/**
+ * death 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface DeathFilter {
+  conceptset?: Identifier;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  date?: DateWithOperator;
+  deathType?: IdentifierWithOperator;
+  cause?: NumberWithOperator;
 }
 
-import { ConditionEraProperties, ConditionOccurrenceProperties, DrugExposureProperties, DrugEraProperties } from './Criteria';
-
-export class Criteria {
-  CriteriaType?: string = null;
-  CriteriaName: string = "";
-  Domain?: string = null;
-  CodesetId?: number = null;
-  OccurrenceStartDate?: any;
-  OccurrenceEndDate?: any;
-  FirstOccurrenceOnly?: boolean = false;
-  DateAdjustment?: DateAdjustment = null;
-  
-  // First property for history checks
-  First?: boolean = false;
-  
-  // Domain-specific nested properties
-  ConditionEra?: ConditionEraProperties;
-  ConditionOccurrence?: ConditionOccurrenceProperties;
-  DrugExposure?: DrugExposureProperties;
-  DrugEra?: DrugEraProperties;
-  
-  // ConditionOccurrence
-  ConditionTypeExclude?: boolean;
-  ConditionType?: number[];
-  ConditionSourceConcept?: number;
-  ConditionStatus?: number[];
-  ConditionStatusExclude?: boolean;
-  StopReason?: TextFilter;
-  
-  // Death
-  DeathDate?: any;
-  DeathType?: number[];
-  DeathTypeExclude?: boolean;
-  
-  // DeviceExposure
-  DeviceType?: number[];
-  DeviceTypeExclude?: boolean;
-  UniqueDeviceId?: TextFilter;
-  Quantity?: NumericRange;
-  DeviceSourceConcept?: number;
-  
-  // DoseEra
-  DoseValue?: NumericRange;
-  UnitConceptId?: number;
-  EraStartDate?: any;
-  EraEndDate?: any;
-  
-  // DrugExposure
-  DrugType?: number[];
-  DrugTypeExclude?: boolean;
-  Refills?: NumericRange;
-  DaysSupply?: NumericRange;
-  Route?: number[];
-  RouteExclude?: boolean;
-  EffectiveDrugDose?: NumericRange;
-  DoseUnit?: number[];
-  DoseUnitExclude?: boolean;
-  LotNumber?: TextFilter;
-  DrugSourceConcept?: number;
-  
-  // DrugEra
-  EraLength?: NumericRange;
-  OccurrenceCount?: NumericRange;
-  GapDays?: NumericRange;
-  
-  // Measurement
-  MeasurementType?: number[];
-  MeasurementTypeExclude?: boolean;
-  Operator?: number[];
-  OperatorExclude?: boolean;
-  Value?: any;
-  ValueAsNumber?: NumericRange;
-  ValueAsString?: TextFilter;
-  ValueAsConcept?: number[];
-  ValueAsConceptExclude?: boolean;
-  Unit?: number[];
-  UnitExclude?: boolean;
-  MeasurementSourceConcept?: number;
-  RangeLow?: number;
-  RangeHigh?: number;
-  RangeLowRatio?: number;
-  RangeHighRatio?: number;
-  
-  // Observation
-  ObservationType?: number[];
-  ObservationTypeExclude?: boolean;
-  Qualifier?: TextFilter;
-  ValueAsDateTime?: any;
-  ObservationSourceConcept?: number;
-  
-  // ObservationPeriod
-  AgeAtStart?: NumericRange;
-  AgeAtEnd?: NumericRange;
-  UserDefinedPeriod?: boolean = false;
-  PeriodStartDate?: any;
-  PeriodEndDate?: any;
-  PeriodType?: number[];
-  PeriodTypeExclude?: boolean;
-  PeriodLength?: number;
-  
-  // ProcedureOccurrence
-  ProcedureType?: number[];
-  ProcedureTypeExclude?: boolean;
-  Modifier?: TextFilter;
-  ProcedureQuantity?: NumericRange;
-  ProcedureSourceConcept?: number;
-  
-  // Specimen
-  SpecimenType?: number[];
-  SpecimenTypeExclude?: boolean;
-  SpecimenUnit?: number[];
-  SpecimenUnitExclude?: boolean;
-  AnatomicSite?: number[];
-  AnatomicSiteExclude?: boolean;
-  DiseaseStatus?: number[];
-  DiseaseStatusExclude?: boolean;
-  SpecimenSourceConcept?: number;
-  SourceId?: string;
-  
-  // VisitOccurrence & VisitDetail
-  VisitType?: number[];
-  VisitTypeExclude?: boolean;
-  VisitLength?: NumericRange;
-  VisitSourceConcept?: number;
-  VisitDetailStartDate?: any;
-  VisitDetailEndDate?: any;
-  VisitDetailLength?: number;
-  VisitDetailSourceConcept?: number;
-  
-  // Additional Shared Properties
-  Age?: NumericRange;
-  Gender?: number[];
-  GenderExclude?: boolean;
-  Race?: number[];
-  RaceExclude?: boolean;
-  Ethnicity?: number[];
-  EthnicityExclude?: boolean;
-  
-  // PayerPlanPeriod
-  PayerPlanPeriodStartDate?: any;
-  PayerPlanPeriodEndDate?: any;
-  PayerConcept?: number;
-  PayerSourceConcept?: number;
-  PlanConcept?: number;
-  PlanSourceConcept?: number;
-  SponsorConcept?: number;
-  SponsorSourceConcept?: number;
-  StopReasonConcept?: number;
-  StopReasonSourceConcept?: number;
-  Payer?: TextFilter;
-  Plan?: TextFilter;
-  Sponsor?: TextFilter;
-  TerminationReason?: TextFilter;
-  
-  // LocationRegion
-  RegionConcept?: number;
-  RegionSourceConcept?: number;
-  StartDate?: any;
-  EndDate?: any;
-  
-  // For conceptset selections
-  VisitDetailTypeCS?: ConceptSetSelection;
-  GenderCS?: ConceptSetSelection;
-  ProviderSpecialtyCS?: ConceptSetSelection;
-  PlaceOfServiceCS?: ConceptSetSelection;
-  
-  // For correlated criteria
-  CorrelatedCriteria?: any;
+/**
+ * device_exposure 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface DeviceExposureFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  deviceType?: IdentifierWithOperator;
+  visitType?: IdentifierWithOperator;
+  uniqueDeviceId?: StringWithOperator;
+  quantity?: NumberWithOperator;
+  source?: IdentifierWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
 }
 
-export class ConditionOccurrence extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "ConditionOccurrence";
-    this.CriteriaName = "Condition Occurrence";
-    this.Domain = "condition";
-  }
+/**
+ * dose_era 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface DoseEraFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  startAge?: NumberWithOperator;
+  endAge?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  doseUnit?: IdentifierWithOperator;
+  length?: NumberWithOperator;
+  doseValue?: NumberWithOperator;
 }
 
-export class ConditionEra extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "ConditionEra";
-    this.CriteriaName = "Condition Era";
-    this.Domain = "condition";
-  }
+/**
+ * drug_era 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface DrugEraFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  startAge?: NumberWithOperator;
+  endAge?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  length?: NumberWithOperator;
+  eraExposureCount?: NumberWithOperator;
 }
 
-export class Death extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "Death";
-    this.CriteriaName = "Death";
-    this.Domain = "death";
-  }
+/**
+ * drug_exposure 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface DrugExposureFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  drugType?: IdentifierWithOperator;
+  visitType?: IdentifierWithOperator;
+  stopReason?: StringWithOperator;
+  refill?: NumberWithOperator;
+  quantity?: NumberWithOperator;
+  daysSupply?: NumberWithOperator;
+  routeType?: IdentifierWithOperator;
+  effectiveDose?: NumberWithOperator;
+  doseUnit?: NumberWithOperator;
+  lotNumber?: StringWithOperator;
+  source?: IdentifierWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
 }
 
-export class DeviceExposure extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "DeviceExposure";
-    this.CriteriaName = "Device Exposure";
-    this.Domain = "device";
-  }
+/**
+ * measurement 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface MeasurementFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  date?: DateWithOperator;
+  measurementType?: IdentifierWithOperator;
+  visitType?: IdentifierWithOperator;
+  operatorType?: IdentifierWithOperator;
+  valueAsNumber?: NumberWithOperator;
+  valueAsConcept?: IdentifierWithOperator;
+  unitType?: IdentifierWithOperator;
+  abnormal?: boolean;
+  rangeLow?: NumberWithOperator;
+  rangeHigh?: NumberWithOperator;
+  //rangeLowRatio?: NumberWithOperator;
+  //rangeHighRatio?: NumberWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
+  source?: IdentifierWithOperator;
 }
 
-export class DoseEra extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "DoseEra";
-    this.CriteriaName = "Dose Era";
-    this.Domain = "drug";
-  }
+/**
+ * observation 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface ObservationFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  date?: DateWithOperator;
+  observationType?: IdentifierWithOperator;
+  visitType?: IdentifierWithOperator;
+  valueAsNumber?: NumberWithOperator;
+  valueAsString?: StringWithOperator;
+  valueAsConcept?: IdentifierWithOperator;
+  qualifierType?: IdentifierWithOperator;
+  unitType?: IdentifierWithOperator;
+  source?: IdentifierWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
 }
 
-export class DrugEra extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "DrugEra";
-    this.CriteriaName = "Drug Era";
-    this.Domain = "drug";
-  }
+/**
+ * observation_period 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface ObservationPeriodFilter {
+  first?: boolean;
+  startAge?: NumberWithOperator;
+  endAge?: NumberWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  //periodType?: BigIntWithOperator;
+  length?: NumberWithOperator;
 }
 
-export class DrugExposure extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "DrugExposure";
-    this.CriteriaName = "Drug Exposure";
-    this.Domain = "drug";
-  }
+/**
+ * procedure_occurrence 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface ProcedureOccurrenceFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  procedureType?: IdentifierWithOperator;
+  visitType?: IdentifierWithOperator;
+  modifierType?: IdentifierWithOperator;
+  quantity?: NumberWithOperator;
+  source?: IdentifierWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
 }
 
-export class Measurement extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "Measurement";
-    this.CriteriaName = "Measurement";
-    this.Domain = "measurement";
-  }
+/**
+ * specimen 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface SpecimenFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  date?: DateWithOperator;
+  specimenType?: IdentifierWithOperator;
+  quantity?: NumberWithOperator;
+  unitType?: IdentifierWithOperator;
+  anatomicSiteType?: IdentifierWithOperator;
+  diseaseStatus?: IdentifierWithOperator;
+  //source?: StringWithOperator;
 }
 
-export class Observation extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "Observation";
-    this.CriteriaName = "Observation";
-    this.Domain = "observation";
-  }
+/**
+ * visit_occurrence 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface VisitOccurrenceFilter {
+  conceptset?: Identifier;
+  first?: boolean;
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  visitType?: IdentifierWithOperator;
+  length?: NumberWithOperator;
+  source?: IdentifierWithOperator;
+  providerSpecialty?: IdentifierWithOperator;
+  placeOfService?: NumberWithOperator;
+  //location?: NumberWithOperator;
 }
 
-export class ObservationPeriod extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "ObservationPeriod";
-    this.CriteriaName = "Observation Period";
-    this.Domain = "observation_period";
-  }
+/**
+ * demographic 도메인에 대한 필터 인터페이스입니다.
+ */
+export interface DemographicFilter {
+  age?: NumberWithOperator;
+  gender?: IdentifierWithOperator;
+  startDate?: DateWithOperator;
+  endDate?: DateWithOperator;
+  raceType?: IdentifierWithOperator;
+  ethnicityType?: IdentifierWithOperator;
 }
 
-export class PayerPlanPeriod extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "PayerPlanPeriod";
-    this.CriteriaName = "Payer Plan Period";
-    this.Domain = "payer_plan_period";
-  }
-}
-
-export class ProcedureOccurrence extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "ProcedureOccurrence";
-    this.CriteriaName = "Procedure Occurrence";
-    this.Domain = "procedure";
-  }
-}
-
-export class Specimen extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "Specimen";
-    this.CriteriaName = "Specimen";
-    this.Domain = "specimen";
-  }
-}
-
-export class VisitOccurrence extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "VisitOccurrence";
-    this.CriteriaName = "Visit Occurrence";
-    this.Domain = "visit";
-  }
-}
-
-export class VisitDetail extends Criteria {
-  // Don't declare these properties here since they're already in the base class 
-  
-  constructor() {
-    super();
-    this.CriteriaType = "VisitDetail";
-    this.CriteriaName = "Visit Detail";
-    this.Domain = "visit_detail";
-  }
-}
-
-export class LocationRegion extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "LocationRegion";
-    this.CriteriaName = "Location Region";
-    this.Domain = "location";
-  }
-}
-
-export class DemographicCriteria extends Criteria {
-  constructor() {
-    super();
-    this.CriteriaType = "DemographicCriteria";
-    this.CriteriaName = "Demographics";
-    this.Domain = null;
-  }
-}
-
-export class ObservationFilter {
-  ObservationTypeExclude: boolean = false;
-  ObservationType: number[] = [];
-  
-  constructor(options?: any) {
-    if (options) {
-      Object.assign(this, options);
-    }
-  }
-}
-
-export class WindowedCriteria {
-  Criteria?: Criteria;
-  Window?: Window;
-  
-  constructor(options?: any) {
-    if (options) {
-      Object.assign(this, options);
-    }
-  }
-}
-
-export class ResultLimit {
-  Type: number = 0;
-  Count: number = 0;
-}
-
-export class CriteriaGroup {
-  Type: string = "ALL";
-  CriteriaList: (Criteria | WindowedCriteria)[] = [];
-  DemographicCriteriaList: DemographicCriteria[] = [];
-  Groups: CriteriaGroup[] = [];
-  Count: number = 0;
-  
-  constructor(options?: any) {
-    if (options) {
-      Object.assign(this, options);
-    }
-  }
-  
-  /**
-   * Checks if the criteria group is empty (has no criteria of any kind)
-   * @returns true if the group has no criteria, otherwise false
-   */
-  isEmpty(): boolean {
-    return (!this.CriteriaList || this.CriteriaList.length === 0) && 
-           (!this.DemographicCriteriaList || this.DemographicCriteriaList.length === 0) &&
-           (!this.Groups || this.Groups.length === 0);
-  }
-}
-
-export class CorelatedCriteria {
-  Criteria?: Criteria;
-  StartWindow?: Window;
-  EndWindow?: Window;
-  Occurrence?: Occurrence;
-  RestrictVisit?: boolean = false;
-  // Properties to be compatible with Criteria
-  CriteriaType?: string;
-  CriteriaName?: string;
-  Domain?: string;
-  CodesetId?: number;
-  // Add correlated criteria specific properties
-  CorrelatedCriteria?: any;
-  
-  constructor(options?: any) {
-    if (options) {
-      Object.assign(this, options);
-    }
-  }
-}
-
-export class InclusionRule {
-  name: string = "";
-  description?: string;
-  expression?: CriteriaGroup;
-  
-  constructor(options?: any) {
-    if (options) {
-      Object.assign(this, options);
-    }
-  }
-}
-
-export class PrimaryCriteria {
-  // PascalCase로 변경 (Java와 일치)
-  CriteriaList: Criteria[] = [];
-  ObservationWindow?: Window;
-  PrimaryCriteriaLimit?: ResultLimit;
-  
-  constructor(options?: any) {
-    if (options) {
-      // Java 스타일 속성 직접 매핑
-      if (options.CriteriaList) {
-        this.CriteriaList = options.CriteriaList;
-      }
-      
-      if (options.ObservationWindow) {
-        // ObservationWindow 처리
-        this.ObservationWindow = {
-          // Window 인터페이스와 호환되도록 변환
-          Start: options.ObservationWindow.PriorDays !== undefined 
-            ? { Value: options.ObservationWindow.PriorDays, Op: "eq" } 
-            : null,
-          End: options.ObservationWindow.PostDays !== undefined 
-            ? { Value: options.ObservationWindow.PostDays, Op: "eq" } 
-            : null,
-          UseIndexEnd: false,
-          UseEventEnd: false
-        };
-      }
-      
-      if (options.PrimaryCriteriaLimit) {
-        this.PrimaryCriteriaLimit = options.PrimaryCriteriaLimit;
-      }
-      
-      // 남은 속성 적용
-      Object.assign(this, options);
-    }
-  }
-}
-
-export class CohortExpression {
-  cdmVersionRange?: string;
-  
-  // PascalCase로 변경 (Java와 일치)
-  PrimaryCriteria?: PrimaryCriteria;
-  AdditionalCriteria?: CriteriaGroup;
-  
-  ObservationWindow?: Window;
-  
-  ConceptSets: ConceptSet[] = [];
-  
-  includeAllDescendants: boolean = true;
-  includedCovariateConceptIds: number[] = [];
-  CensorWindow?: Window;
-  CensoringCriteria: CorelatedCriteria[] = [];
-  QualifiedLimit?: ResultLimit;
-  ExpressionLimit?: ResultLimit;
-  InclusionRules: InclusionRule[] = [];
-  censoring: ObservationFilter = new ObservationFilter();
-  CollapseSettings?: CollapseSettings;
-  EndStrategy?: EndStrategy;
-  
-  constructor(options?: any) {
-    if (options) {
-      // Initial copy of all properties
-      Object.assign(this, options);
-      
-      // Ensure nested objects have proper types - use PascalCase directly (Java style)
-      if (options.PrimaryCriteria) {
-        this.PrimaryCriteria = new PrimaryCriteria(options.PrimaryCriteria);
-      }
-      
-      if (options.AdditionalCriteria) {
-        this.AdditionalCriteria = new CriteriaGroup(options.AdditionalCriteria);
-      }
-      
-      if (options.InclusionRules) {
-        this.InclusionRules = options.InclusionRules.map((rule: any) => new InclusionRule(rule));
-      }
-      
-      if (options.censoring) {
-        this.censoring = new ObservationFilter(options.censoring);
-      }
-      
-      // Handle concept sets properly - use PascalCase for ConceptSets
-      if (Array.isArray(options.ConceptSets)) {
-        console.log('Found ConceptSets property');
-        // Import at the top will cause circular dependency issues
-        // To avoid this, we'll import dynamically here
-        const ConceptSet = require('./ConceptSet').default;
-        
-        this.ConceptSets = options.ConceptSets.map((cs: any) => {
-          console.log(`Processing concept set ${cs.id} with name '${cs.name}'`);
-          return new ConceptSet(cs);
-        });
-        
-        console.log(`Processed ${this.ConceptSets.length} concept sets`);
-      }
-    }
-  }
-}
-
-export default CohortExpression;
 """
 
 def map_criteria_info(criteria_type):
     """
-    CriteriaType을 CriteriaName(규격), Domain(규격), Domain_id(clickhouse 도메인)로 매핑
+    CriteriaType을 Domain_id(clickhouse 도메인)와 type(OMOP CDM type)으로 매핑
     """
     criteria_info = {
         "ConditionEra": {
-            "CriteriaName": "Condition Era",
-            "Domain": "condition",
-            "Domain_id": "Condition"
+            "Domain_id": "Condition",
+            "type": "condition_era"
         },
         "ConditionOccurrence": {
-            "CriteriaName": "Condition Occurrence",
-            "Domain": "condition",
-            "Domain_id": "Condition"
+            "Domain_id": "Condition",
+            "type": "condition_occurrence"
         },
         "Death": {
-            "CriteriaName": "Death",
-            "Domain": "death",
-            "Domain_id": "Death"
+            "Domain_id": "Death",
+            "type": "death"
         },
         "DeviceExposure": {
-            "CriteriaName": "Device Exposure",
-            "Domain": "device",
-            "Domain_id": "Device"
+            "Domain_id": "Device",
+            "type": "device_exposure"
         },
         "DoseEra": {
-            "CriteriaName": "Dose Era",
-            "Domain": "drug",
-            "Domain_id": "Drug"
+            "Domain_id": "Drug",
+            "type": "dose_era"
         },
         "DrugEra": {
-            "CriteriaName": "Drug Era",
-            "Domain": "drug",
-            "Domain_id": "Drug"
+            "Domain_id": "Drug",
+            "type": "drug_era"
         },
         "DrugExposure": {
-            "CriteriaName": "Drug Exposure",
-            "Domain": "drug",
-            "Domain_id": "Drug"
+            "Domain_id": "Drug",
+            "type": "drug_exposure"
         },
         "Measurement": {
-            "CriteriaName": "Measurement",
-            "Domain": "measurement",
-            "Domain_id": "Measurement"
+            "Domain_id": "Measurement",
+            "type": "measurement"
         },
         "Observation": {
-            "CriteriaName": "Observation",
-            "Domain": "observation",
-            "Domain_id": "Observation"
+            "Domain_id": "Observation",
+            "type": "observation"
         },
         "ObservationPeriod": {
-            "CriteriaName": "Observation Period",
-            "Domain": "observation_period",
-            "Domain_id": "Observation"
+            "Domain_id": "Observation",
+            "type": "observation_period"
         },
         "ProcedureOccurrence": {
-            "CriteriaName": "Procedure Occurrence",
-            "Domain": "procedure",
-            "Domain_id": "Procedure"
+            "Domain_id": "Procedure",
+            "type": "procedure_occurrence"
         },
         "Specimen": {
-            "CriteriaName": "Specimen",
-            "Domain": "specimen",
-            "Domain_id": "Specimen"
+            "Domain_id": "Specimen",
+            "type": "specimen"
         },
         "VisitOccurrence": {
-            "CriteriaName": "Visit Occurrence",
-            "Domain": "visit",
-            "Domain_id": "Visit"
+            "Domain_id": "Visit",
+            "type": "visit_occurrence"
         },
         "VisitDetail": {
-            "CriteriaName": "Visit Detail",
-            "Domain": "visit_detail",
-            "Domain_id": "Visit"
+            "Domain_id": "Visit",
+            "type": "visit_detail"
         },
         "LocationRegion": {
-            "CriteriaName": "Location Region",
-            "Domain": "location",
-            "Domain_id": "Geography"
+            "Domain_id": "Geography",
+            "type": "location_region"
         },
         "DemographicCriteria": {
-            "CriteriaName": "Demographics",
-            "Domain": None,
-            "Domain_id": None
+            "Domain_id": "Demographic",
+            "type": "demographic"
         }
     }
     
-    return criteria_info.get(criteria_type, None)
+    return criteria_info.get(criteria_type)

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -32,33 +32,33 @@ clickhouse_client = Client(
 STRICT_REQUIREMENT = f"""
 Instructions
 Strict requirements:
-1. For each item in the inclusion section:
-   - You must include the following keys:
-     - "CriteriaType" (must be one of: ["ConditionEra", "ConditionOccurrence", "Death", "DeviceExposure", "DoseEra", "DrugEra", "DrugExposure", "Measurement", "Observation", "ObservationPeriod", "ProcedureOccurrence", "Specimen", "VisitOccurrence", "VisitDetail", "LocationRegion", "DemographicCriteria"])
-     - "Domain" (will be automatically mapped based on CriteriaType)
-     - "Domain_id" (will be automatically mapped based on CriteriaType)
-     - "CodesetId" (will be filled later)
-     - "CriteriaName" (human readable name)
-   
-   - The "CriteriaType" must be one of the following valid values:
-     ["ConditionEra", "ConditionOccurrence", "Death", "DeviceExposure", "DoseEra", "DrugEra", "DrugExposure", "Measurement", "Observation", "ObservationPeriod", "ProcedureOccurrence", "Specimen", "VisitOccurrence"]
+1. Structure:
+   - conceptsets: Array of concept sets, each containing:
+     * conceptset_id: String (starting from "0")
+     * name: String (medical term)
+     * items: Array of concept objects from database
+   - cohort: Array of groups, each containing:
+     * containers: Array of containers with filters
+     * not: Boolean (true for exclusion criteria)
 
-2. For Measurement criteria:
-   - Include "ValueAsNumber" with appropriate operator ("gt", "lt", "eq", etc.)
-   - For any field such as "MeasurementType", "DrugType", "ConditionType", etc., 
+2. Each filter MUST include:
+   - type: The type of criteria (must be one of: ["ConditionEra", "ConditionOccurrence", "Death", "DeviceExposure", "DoseEra", "DrugEra", "DrugExposure", "Measurement", "Observation", "ObservationPeriod", "ProcedureOccurrence", "Specimen", "VisitOccurrence", "VisitDetail", "LocationRegion", "DemographicCriteria"])
+   - first: true
+   - conceptset: String (matching conceptset_id)
+
+3. For Measurement criteria:
+   - Include "valueAsNumber" with appropriate operator ("gt", "lt", "eq", etc.)
+   - For any field such as "measurementType", "drugType", "conditionType", etc., 
      do NOT invent or fabricate placeholder concept_id values
    - If a concept_id is not available, explicitly set the value to null
 
-3. You must use the exact concept_id and domain_id values provided in the concept list.
-   - Follow the exact structure shown in the schema
-   - Avoid creating entirely new diseases or medications unrelated to the input.
-   - Avoid adding extra qualifiers, descriptions, or text that didn't exist in the original term.
-   - **Do NOT fabricate or hallucinate any concept_id, domain_id, or type values.**
-   - If any required value is missing or uncertain, omit that item from the output.
-   - Include empty objects ({{}}) for type-specific properties
-   - Include ConceptName for reference (this will be used for concept mapping)
-   
-4. The final JSON **must strictly conform** to the OMOP CDM cohort JSON schema below:
+4. For age criteria:
+   - Use "ObservationPeriod" as type
+   - Include "age" with appropriate operator
+"""
+
+STRICT_REQUIREMENT_SCHEMA = f"""
+5. The final JSON **must strictly conform** to the OMOP CDM cohort JSON schema below:
 OMOP CDM cohort JSON schema:
 {cohort_json_schema.JSON_SCHEMA}
 
@@ -68,29 +68,19 @@ DO NOT include or use any example data, JSON schema, or instructions shown above
 Your output must strictly reflect criteria that appear in the original text below.
 
 Input Text Example:
-3.1. Inclusion criteria  
-Patients who are 20 years old or older.
-Patients with hemodialysis.
-Patients using ESA therapy for at least three months.
-Patients with iron deficiency anemia.
-
-3.2. Exclusion criteria  
-Patients in intensive care unit.  
-Patients with hemoglobin value more than 13 g/dL.  
-Kidney transplant patients.  
-Patients with sepsis or active infections.
+{cohort_json_schema.JSON_INPUT_EXAMPLE}
 
 Output Example:
 {cohort_json_schema.JSON_OUTPUT_EXAMPLE}
 
-5. Output format:
+6. Output format:
     - Return only the JSON structure
     - Do not include any explanations or markdown
     - Ensure all required fields are present
     - DO NOT include explanations, comments, or additional text.
     - Return only raw JSON without any labels, headers, or formatting.
     - DO NOT include any Markdown formatting or explanations
-    - Any usage of Markdown fosmatting like ```json or ``` → strictly forbidden
+    - Any usage of Markdown formatting like ```json or ``` → strictly forbidden
     - Use valueAsNumber only for measurable criteria
     - Ensure that each domain has the correct key: drugType, procedureType, observationType, etc.
 """
@@ -104,6 +94,48 @@ You are an AI assistant that extracts key OMOP-compatible medical keywords from 
 These keywords will be used to search for concept codes in a structured OMOP CDM concept database.
 
 {STRICT_REQUIREMENT}
+
+## Rules
+1. Extract only the following information for each criterion:
+   - type: The type of criteria (must be one of: ["ConditionOccurrence", "Death", "DeviceExposure", "DoseEra", "DrugEra", "DrugExposure", "Measurement", "Observation", "ObservationPeriod", "ProcedureOccurrence", "Specimen", "VisitOccurrence", "VisitDetail", "LocationRegion", "DemographicCriteria"])
+   - name: The medical term or concept name
+   - exclusion: Boolean (true for exclusion criteria)
+   - valueAsNumber: For measurement criteria (MANDATORY for Measurement type)
+   - age: For age criteria (optional)
+
+2. Important:
+   - [CRITICAL] Only extract criteria from sections clearly labeled as inclusion/exclusion criteria
+   - [CRITICAL] Each concept should appear only ONCE
+   - [CRITICAL] DO NOT include any Markdown formatting
+   - [CRITICAL] DO NOT include explanations or additional text
+   - [CRITICAL] Return ONLY the JSON object, no other text
+   - [CRITICAL] DO NOT include any introductory text like "Here is..." or "The extracted criteria are:"
+   - [CRITICAL] DO NOT include any ```json or ``` markers
+   - [CRITICAL] For Measurement type:
+     * MUST include valueAsNumber with operator and value
+     * Example: "Hemoglobin > 13" → {{ "valueAsNumber": {{ "gt": 13 }} }}
+   - For age criteria:
+     * Use "ObservationPeriod" as type
+     * Include age value and operator
+   - For conditions:
+     * Use "ConditionOccurrence" as type (NOT ConditionEra)
+
+3. Return ONLY this exact JSON format (no other text):
+{{
+  "criteria": [
+    {{
+      "type": "ConditionOccurrence",
+      "name": "Diabetes",
+      "exclusion": false
+    }},
+    {{
+      "type": "Measurement",
+      "name": "Hemoglobin",
+      "exclusion": true,
+      "valueAsNumber": {{ "gt": 13 }}
+    }}
+  ]
+}}
 """
 # 코호트 키워드 뽑기 - user
 COHORT_EXTRACTION_PROMPT = """
@@ -111,166 +143,7 @@ You are an AI assistant specialized in processing medical cohort selection crite
 Your task is to extract medical conditions, treatments, medications, and procedures mentioned explicitly in the provided text
 and classify them into appropriate OMOP CDM domains.
 
-## Rules
-1. Structure:
-   - PrimaryCriteria: The MAIN condition/procedure that defines the cohort (usually the first inclusion criteria)
-   - AdditionalCriteria:
-     - Groups[0] (Type: "ALL"): Additional inclusion criteria
-     - Groups[1] (Type: "NONE"): Exclusion criteria
-
-2. Each criteria MUST include:
-   - "CriteriaType": The type of criteria (e.g., "ConditionOccurrence", "DrugExposure", etc.)
-   - "ConceptName": [CRITICAL] This is the exact medical term that will be used for database search
-     * Must be precise and standardized medical terminology
-     * Avoid general descriptions or complex phrases
-     * Examples of good ConceptName:
-       - "sepsis" (not "sepsis or active infections")
-       - "hemodialysis" (not "patients with hemodialysis")
-       - "iron deficiency anemia" (exact medical condition)
-     * This field is crucial for finding correct concept_ids in the database
-   - Other required fields will be filled automatically
-
-3. Example format:
-   {{
-     "PrimaryCriteria": {{
-       "CriteriaList": [
-         {{
-           "CriteriaType": "ProcedureOccurrence",
-           "ConceptName": "hemodialysis",
-           "ProcedureOccurrence": {{}}
-         }}
-       ],
-       "PrimaryCriteriaLimit": {{
-         "Type": 0,
-         "Count": 1
-       }}
-     }},
-     "AdditionalCriteria": {{
-       "Type": "ALL",
-       "CriteriaList": [],
-       "DemographicCriteriaList": [],
-       "Groups": [
-         {{
-           "Type": "ALL",  # Inclusion criteria - MUST be met
-           "CriteriaList": [
-             {{
-               "Criteria": {{
-                 "CriteriaType": "ObservationPeriod",
-                 "AgeAtStart": {{
-                   "Value": 20,
-                   "Op": "gte"
-                 }},
-                 "ObservationPeriod": {{}}
-               }}
-             }},
-             {{
-               "Criteria": {{
-                 "CriteriaType": "DrugExposure",
-                 "ConceptName": "erythropoiesis stimulating agent",
-                 "DrugExposure": {{}}
-               }}
-             }},
-             {{
-               "Criteria": {{
-                 "CriteriaType": "ConditionOccurrence",
-                 "ConceptName": "iron deficiency anemia",
-                 "ConditionOccurrence": {{}}
-               }}
-             }}
-           ],
-           "DemographicCriteriaList": [],
-           "Groups": []
-         }},
-         {{
-           "Type": "NONE",  # Exclusion criteria - MUST NOT be met
-           "CriteriaList": [
-             {{
-               "Criteria": {{
-                 "CriteriaType": "VisitOccurrence",
-                 "ConceptName": "intensive care unit",
-                 "VisitOccurrence": {{}}
-               }}
-             }},
-             {{
-               "Criteria": {{
-                 "CriteriaType": "Measurement",
-                 "ConceptName": "hemoglobin",
-                 "Measurement": {{}},
-                 "ValueAsNumber": {{
-                   "Value": 13,
-                   "Op": "gt"
-                 }}
-               }}
-             }},
-             {{
-               "Criteria": {{
-                 "CriteriaType": "ProcedureOccurrence",
-                 "ConceptName": "kidney transplant",
-                 "ProcedureOccurrence": {{}}
-               }}
-             }},
-             {{
-               "Criteria": {{
-                 "CriteriaType": "ConditionOccurrence",
-                 "ConceptName": "sepsis",
-                 "ConditionOccurrence": {{}}
-               }}
-             }}
-           ],
-           "DemographicCriteriaList": [],
-           "Groups": []
-         }}
-       ]
-     }}
-   }}
-
-4. Important:
-   - [CRITICAL] DO NOT duplicate conditions in CriteriaList
-   - [CRITICAL] Each unique ConceptName should appear only ONCE in PrimaryCriteria
-   - [CRITICAL] Each unique ConceptName should appear only ONCE in each AdditionalCriteria group
-   - The first inclusion criteria should be used as PrimaryCriteria
-   - All inclusion criteria (except Primary) go to AdditionalCriteria Groups[0] with Type: "ALL"
-   - All exclusion criteria go to AdditionalCriteria Groups[1] with Type: "NONE"
-   - DO NOT generate concept_id - it will be retrieved separately
-   - DO NOT include any Markdown formatting
-   - DO NOT include explanations or additional text
-   - ALWAYS include ConceptName for each criteria
-   - Return only the JSON output in the correct format
-   - For age criteria:
-     * Use "ObservationPeriod" as CriteriaType
-     * Include "AgeAtStart" or "AgeAtEnd" with "Value" and "Op"
-     * Valid operators: "gt", "lt", "gte", "lte", "eq", "bt", "!bt"
-   - For other numeric criteria (lab values, etc.):
-     * Use "Measurement" as CriteriaType
-     * Include "ValueAsNumber" with "Value" and "Op"
-   
-   - [CRITICAL] Only extract criteria from sections clearly labeled as inclusion/exclusion criteria
-     * Usually found in sections labeled as "Inclusion criteria", "Exclusion criteria", "Eligibility criteria"
-     * These criteria are typically grouped together in a single section/paragraph
-     * Ignore any medical terms or conditions mentioned in other parts of the text (e.g., results, discussion)
-   
-   - [CRITICAL] Only extract criteria that are EXPLICITLY stated as inclusion/exclusion criteria
-     * Do not include conditions mentioned in other contexts
-     * Do not include conditions from case descriptions or examples
-     * Do not include conditions from background or discussion sections
-   
-   - [CRITICAL] For each criteria:
-     * Extract ONLY the core medical concept
-     * Remove patient-related phrases (e.g., "patients with", "history of")
-     * Remove temporal qualifiers unless they are critical to the criteria
-     * Remove descriptive text that isn't part of the medical concept
-
-Example of what to extract:
-Text: "The study included patients with chronic kidney disease who were receiving hemodialysis. Patients with a history of cardiovascular disease were excluded."
-✓ DO extract:
-  - Inclusion: "hemodialysis", "chronic kidney disease"
-  - Exclusion: "cardiovascular disease"
-✗ DON'T extract:
-  - Random medical terms mentioned in results
-  - Conditions discussed in background
-  - Outcomes or complications
-
-Extract the cohort selection criteria from the following text and return only a valid JSON response:
+Extract the cohort selection criteria from the following text and return ONLY the JSON response:
 {text}
 """
 
@@ -290,6 +163,7 @@ Instructions:
      `"Hemoglobin level over 13 g/dL"` → `"Hemoglobin"`
 
 {STRICT_REQUIREMENT}
+{STRICT_REQUIREMENT_SCHEMA}
 
 **Modified Examples**:
 - Input: `"ESA"` → Output: `Erythropoiesis Stimulating Agent`
@@ -310,87 +184,150 @@ def extract_text_from_pdf(pdf_path) -> str:
     return text
 
 # 2. 키워드 검색어 + type 자동 추출
-def extract_terms_from_text(text: str) -> dict:
+def extract_terms_from_text(text: str) -> list:
     """
-    PDF 텍스트에서 코호트 기준을 추출하여 기본 OMOP CDM JSON 형식으로 반환
-    
-    Args:
-        text (str): PDF에서 추출한 텍스트
-        
-    Returns:
-        dict: 기본 OMOP CDM JSON 형식
+    PDF 텍스트에서 코호트 기준을 추출하여 리스트 형태로 반환
     """
     response = client.chat.completions.create(
         model=model_name,
         messages=[{"role": "system", "content": COHORT_EXTRACTION_SYSTEM_PROMPT},
-                  {"role": "user", "content": COHORT_EXTRACTION_PROMPT.format(text=text)}]
+                  {"role": "user", "content": COHORT_EXTRACTION_PROMPT.format(
+                      text=text,
+                      example=cohort_json_schema.JSON_OUTPUT_EXAMPLE
+                  )}]
     )
 
     try:
-        # LLM 응답을 JSON으로 변환
-        cohort_json = json.loads(response.choices[0].message.content)
+        # 응답에서 JSON 부분만 추출
+        content = response.choices[0].message.content.strip()
         
-        # PrimaryCriteria의 CriteriaList 처리
-        if "PrimaryCriteria" in cohort_json and "CriteriaList" in cohort_json["PrimaryCriteria"]:
-            for criteria in cohort_json["PrimaryCriteria"]["CriteriaList"]:
-                if "CriteriaType" in criteria:
-                    criteria_info = cohort_json_schema.map_criteria_info(criteria["CriteriaType"])
-                    if criteria_info:
-                        # 기존 정보 보존하면서 새로운 정보 추가
-                        criteria.update({
-                            "CriteriaName": criteria_info["CriteriaName"],
-                            "Domain": criteria_info["Domain"],
-                            "Domain_id": criteria_info["Domain_id"]
-                        })
-
-        # AdditionalCriteria의 Groups 처리
-        if "AdditionalCriteria" in cohort_json and "Groups" in cohort_json["AdditionalCriteria"]:
-            for group in cohort_json["AdditionalCriteria"]["Groups"]:
-                if "CriteriaList" in group:
-                    for criteria in group["CriteriaList"]:
-                        if "Criteria" in criteria and "CriteriaType" in criteria["Criteria"]:
-                            criteria_info = cohort_json_schema.map_criteria_info(criteria["Criteria"]["CriteriaType"])
-                            if criteria_info:
-                                # 기존 정보 보존하면서 새로운 정보 추가
-                                criteria["Criteria"].update({
-                                    "CriteriaName": criteria_info["CriteriaName"],
-                                    "Domain": criteria_info["Domain"],
-                                    "Domain_id": criteria_info["Domain_id"]
-                                })
-                                
-                                # ObservationPeriod 타입인 경우 빈 객체 추가
-                                if criteria["Criteria"]["CriteriaType"] == "ObservationPeriod":
-                                    criteria["Criteria"]["ObservationPeriod"] = {}
-        return cohort_json
+        # Markdown 코드 블록 제거
+        if "```json" in content:
+            content = content.split("```json")[1].split("```")[0].strip()
+        elif "```" in content:
+            content = content.split("```")[1].strip()
+        
+        # 불필요한 텍스트 제거
+        if "Here is" in content:
+            content = content.split("Here is")[-1].strip()
+        if "The extracted criteria are:" in content:
+            content = content.split("The extracted criteria are:")[-1].strip()
+        
+        # LLM 응답을 JSON으로 변환
+        cohort_json = json.loads(content)
+        
+        # criteria 리스트 생성
+        criteria_list = []
+        
+        # 모든 criteria 처리
+        for criteria in cohort_json.get("criteria", []):
+            if "type" in criteria and "name" in criteria:
+                criteria_info = cohort_json_schema.map_criteria_info(criteria["type"])
+                if criteria_info:
+                    criteria_list.append({
+                        "type": criteria["type"],
+                        "name": criteria["name"],
+                        "exclusion": criteria.get("exclusion", False),
+                        "valueAsNumber": criteria.get("valueAsNumber"),
+                        "age": criteria.get("age")
+                    })
+        
+        return criteria_list
     
-    except json.JSONDecodeError:
-        print("JSONDecodeError: 응답이 유효한 JSON 형식이 아님")
+    except json.JSONDecodeError as e:
+        print(f"\n[JSONDecodeError]")
+        print(f"Error: {e}")
+        print(f"Response content: {response.choices[0].message.content}")
         return None
     
     except Exception as e:
-        print(f"Unexpected Error: {e}")
+        print(f"\n[Unexpected Error]")
+        print(f"Error: {e}")
+        print(f"Error type: {type(e)}")
+        import traceback
+        print(f"Traceback: {traceback.format_exc()}")
         return None
 
 # 불필요한 정보가 추가된 문구를 제거하는 함수 
 def clean_term(term):
     return re.sub(r"\s*\(.*?\)", "", term).strip() 
 
-# 3. ClickHouse에서 `concept_id` 조회
+# 3. ClickHouse에서 concept 정보 조회
 def get_omop_concept_id(term: str, domain_id: str) -> list:
     cleaned_term = clean_term(term).replace('%', '%%')
     
-    # 일반적인 검색
     query = """
-    SELECT concept_id, concept_name 
+    SELECT 
+        concept_id,
+        concept_name,
+        domain_id,
+        vocabulary_id,
+        concept_class_id,
+        standard_concept,
+        concept_code,
+        valid_start_date,
+        valid_end_date,
+        invalid_reason
     FROM concept 
     WHERE concept_name ILIKE %(term)s 
     AND domain_id = %(domain_id)s 
     AND invalid_reason IS NULL
     LIMIT 3
     """
+    
     results = clickhouse_client.execute(query, {'term': f'%{cleaned_term}%', 'domain_id': domain_id})
     
-    return [(r[0], r[1]) for r in results]
+    # Concept 객체로 변환
+    concepts = []
+    for result in results:
+        concept = {
+            "concept_id": str(result[0]),  # Identifier는 string
+            "concept_name": result[1],
+            "domain_id": result[2],
+            "vocabulary_id": result[3],
+            "concept_class_id": result[4],
+            "standard_concept": result[5],
+            "concept_code": result[6],
+            "valid_start_date": result[7].strftime("%Y-%m-%d") if result[7] else None,  # date를 문자열로 변환
+            "valid_end_date": result[8].strftime("%Y-%m-%d") if result[8] else None,    # date를 문자열로 변환
+            "invalid_reason": result[9],
+            "includeDescendants": True,  # 기본값 설정
+            "includeMapped": True
+        }
+        concepts.append(concept)
+    
+    return concepts
+
+# concept_set_id에 해당하는 filter의 type을 찾아 domain_id를 반환
+def get_concept_set_domain_id(cohort_json: dict, concept_set_id: str) -> str:
+    for group in cohort_json.get("cohort", []):
+        for container in group.get("containers", []):
+            for filter_obj in container.get("filters", []):
+                if filter_obj.get("conceptset") == concept_set_id:
+                    criteria_type = filter_obj["type"]
+                    criteria_info = cohort_json_schema.map_criteria_info(criteria_type)
+                    if criteria_info:
+                        return criteria_info["Domain_id"]
+    return None
+
+# concept_set의 items를 DB에서 조회한 결과로 업데이트
+def update_concept_set_items(concept_set: dict, domain_id: str) -> dict:
+    if not domain_id:
+        return concept_set
+        
+    concept_results = get_omop_concept_id(concept_set["name"], domain_id)
+    if concept_results:
+        concept_set["items"] = concept_results
+    return concept_set
+
+# cohort_json의 conceptset에서 concept_id를 조회하여 업데이트
+def get_concept_ids(cohort_json: dict) -> dict:
+    for concept_set in cohort_json.get("conceptsets", []):
+        if "name" in concept_set and "conceptset_id" in concept_set:
+            domain_id = get_concept_set_domain_id(cohort_json, concept_set["conceptset_id"])
+            concept_set = update_concept_set_items(concept_set, domain_id)
+    
+    return cohort_json
 
 # 4. 검색어 변경하여 재검색
 def refine_search_query(term) -> str:
@@ -402,216 +339,107 @@ def refine_search_query(term) -> str:
 
     return response.choices[0].message.content.strip()
 
-# cohort_json의 ConceptName을 기반으로 DB에서 concept_id를 조회하여 업데이트
-def get_concept_ids(cohort_json: dict) -> dict:
-    # PrimaryCriteria 처리
-    if "PrimaryCriteria" in cohort_json and "CriteriaList" in cohort_json["PrimaryCriteria"]:
-        for criteria in cohort_json["PrimaryCriteria"]["CriteriaList"]:
-            # ObservationPeriod는 concept_id 검색 건너뛰기
-            if criteria.get("CriteriaType") == "ObservationPeriod":
-                continue
-                
-            if "ConceptName" in criteria and "Domain_id" in criteria:
-                search_term = criteria["ConceptName"]  # 원래 검색어
-                concept_results = get_omop_concept_id(search_term, criteria["Domain_id"])
-                if concept_results:
-                    criteria["CodesetId"] = [result[0] for result in concept_results]
-                    criteria["ConceptName"] = search_term
-                    # DB 결과는 나중에 ConceptSets에서 명시하기 위해 임시 저장
-                    criteria["_db_results"] = concept_results  # 임시 저장
-    
-    # AdditionalCriteria 처리
-    if "AdditionalCriteria" in cohort_json and "Groups" in cohort_json["AdditionalCriteria"]:
-        for group in cohort_json["AdditionalCriteria"]["Groups"]:
-            if "CriteriaList" in group:
-                for criteria in group["CriteriaList"]:
-                    if "Criteria" in criteria:
-                        # ObservationPeriod는 concept_id 검색 건너뛰기
-                        if criteria["Criteria"].get("CriteriaType") == "ObservationPeriod":
-                            continue
-                            
-                        if "ConceptName" in criteria["Criteria"] and "Domain_id" in criteria["Criteria"]:
-                            search_term = criteria["Criteria"]["ConceptName"]
-                            concept_results = get_omop_concept_id(search_term, criteria["Criteria"]["Domain_id"])
-                            if concept_results:
-                                criteria["Criteria"]["CodesetId"] = [result[0] for result in concept_results]
-                                criteria["Criteria"]["ConceptName"] = search_term
-                                criteria["Criteria"]["_db_results"] = concept_results
-    
-    return cohort_json
-
-# concept_id가 포함된 cohort_json을 최종 OMOP CDM JSON 형식으로 변환
-def create_omop_json(cohort_json: dict) -> dict:
+# 5. 추출된 criteria를 OMOP CDM JSON 형식으로 변환
+def create_cohort_json(extracted_criteria: list) -> dict:
     result = {
-        "PrimaryCriteria": {
-            "CriteriaList": [],
-            "PrimaryCriteriaLimit": {"Type": 0, "Count": 1}
-        },
-        "AdditionalCriteria": {
-            "Type": "ALL",
-            "CriteriaList": [],
-            "DemographicCriteriaList": [],
-            "Groups": [
-                {"Type": "ALL", "CriteriaList": [], "DemographicCriteriaList": [], "Groups": []},
-                {"Type": "NONE", "CriteriaList": [], "DemographicCriteriaList": [], "Groups": []}
-            ]
-        },
-        "ConceptSets": [],
-        "EndStrategy": {"DateField": "EndDate", "Offset": 0},
-        "cdmVersionRange": ">=5.0.0",
-        "includeAllDescendants": True,
-        "includedCovariateConceptIds": [],
-        "CensoringCriteria": [],
-        "InclusionRules": [],
-        "CollapseSettings": {"CollapseType": "ERA", "EraPad": 0}
+        "conceptsets": [],
+        "cohort": []
     }
     
-    # Criteria 처리 함수
-    def process_criteria(criteria):
-        result_criteria = {
-            key: value for key, value in criteria.items() 
-            if not key.startswith('_')
+    concept_set_id = 0
+    
+    # inclusion criteria 처리
+    inclusion_containers = []
+    exclusion_containers = []
+    
+    for criteria in extracted_criteria:
+        # ConceptSet 생성
+        concept_set = {
+            "conceptset_id": str(concept_set_id),
+            "name": criteria["name"],
+            "items": []  # DB에서 조회 후 업데이트
+        }
+        result["conceptsets"].append(concept_set)
+        
+        # Filter 생성
+        filter_obj = {
+            "type": criteria["type"],
+            "first": True,
+            "conceptset": str(concept_set_id)
         }
         
-        # ObservationPeriod 타입인 경우 특별 처리
-        if criteria.get("CriteriaType") == "ObservationPeriod":
-            if "AgeAtStart" in criteria:
-                result_criteria["AgeAtStart"] = criteria["AgeAtStart"]
-            if "AgeAtEnd" in criteria:
-                result_criteria["AgeAtEnd"] = criteria["AgeAtEnd"]
-            result_criteria["ObservationPeriod"] = {}
-        # Measurement 타입인 경우 ValueAsNumber 처리
-        elif "ValueAsNumber" in criteria:
-            result_criteria["ValueAsNumber"] = criteria["ValueAsNumber"]
-            result_criteria["Measurement"] = {}
+        # 추가 필터 조건
+        if criteria.get("valueAsNumber"):
+            filter_obj["valueAsNumber"] = criteria["valueAsNumber"]
+        if criteria.get("age"):
+            filter_obj["age"] = criteria["age"]
         
-        # 각 CriteriaType에 맞는 빈 객체 추가
-        criteria_type = criteria.get("CriteriaType")
-        if criteria_type:
-            result_criteria[criteria_type] = {}
+        # Container 생성
+        container = {
+            "name": criteria["name"],
+            "filters": [filter_obj]
+        }
         
-        return result_criteria
+        # inclusion/exclusion 구분
+        if criteria.get("exclusion", False):
+            if len(exclusion_containers) > 0:
+                container["operator"] = "AND"
+            exclusion_containers.append(container)
+        else:
+            if len(inclusion_containers) > 0:
+                container["operator"] = "AND"
+            inclusion_containers.append(container)
+        
+        concept_set_id += 1
     
-    # ConceptSet 추가 함수
-    def add_concept_set(concept_id: int, db_name: str, domain_id: str):
-        result["ConceptSets"].append({
-            "id": concept_id,
-            "name": db_name,
-            "expression": {
-                "items": [{
-                    "concept": {
-                        "CONCEPT_ID": concept_id,
-                        "CONCEPT_NAME": db_name,
-                        "DOMAIN_ID": domain_id
-                    }
-                }]
-            }
+    # cohort에 groups 추가
+    if inclusion_containers:
+        result["cohort"].append({
+            "containers": inclusion_containers
         })
     
-    # PrimaryCriteria 처리
-    if "PrimaryCriteria" in cohort_json and "CriteriaList" in cohort_json["PrimaryCriteria"]:
-        for criteria in cohort_json["PrimaryCriteria"]["CriteriaList"]:
-            # 모든 criteria 포함
-            result["PrimaryCriteria"]["CriteriaList"].append(process_criteria(criteria))
-            
-            # ConceptSets 추가
-            if "_db_results" in criteria:
-                for concept_id, db_name in criteria["_db_results"]:
-                    add_concept_set(concept_id, db_name, criteria["Domain_id"])
-    
-    # AdditionalCriteria 처리
-    if "AdditionalCriteria" in cohort_json and "Groups" in cohort_json["AdditionalCriteria"]:
-        for group in cohort_json["AdditionalCriteria"]["Groups"]:
-            if "CriteriaList" not in group:
-                continue
-                
-            # 포함/제외 그룹 결정
-            is_exclusion = group["Type"] == "NONE"
-            target_group = result["AdditionalCriteria"]["Groups"][1] if is_exclusion else result["AdditionalCriteria"]["Groups"][0]
-            
-            # Criteria 처리
-            for criteria in group["CriteriaList"]:
-                if "Criteria" not in criteria:
-                    continue
-                    
-                # Criteria 추가
-                target_group["CriteriaList"].append(process_criteria(criteria["Criteria"]))
-                
-                # ConceptSets 추가
-                if "_db_results" in criteria["Criteria"]:
-                    for concept_id, db_name in criteria["Criteria"]["_db_results"]:
-                        add_concept_set(concept_id, db_name, criteria["Criteria"]["Domain_id"])
+    if exclusion_containers:
+        result["cohort"].append({
+            "not": True,
+            "containers": exclusion_containers
+        })
     
     return result
 
-def remove_duplicates_from_json(cohort_json: dict) -> dict:
-    """
-    JSON에서 중복된 criteria 제거
-    """
-    # PrimaryCriteria에서 중복 제거
-    if "PrimaryCriteria" in cohort_json and "CriteriaList" in cohort_json["PrimaryCriteria"]:
-        seen = set()
-        unique_criteria = []
-        for criteria in cohort_json["PrimaryCriteria"]["CriteriaList"]:
-            key = (criteria.get("CriteriaType"), criteria.get("ConceptName"))
-            if key not in seen:
-                seen.add(key)
-                unique_criteria.append(criteria)
-        cohort_json["PrimaryCriteria"]["CriteriaList"] = unique_criteria
-
-    # AdditionalCriteria Groups에서 중복 제거
-    if "AdditionalCriteria" in cohort_json and "Groups" in cohort_json["AdditionalCriteria"]:
-        for group in cohort_json["AdditionalCriteria"]["Groups"]:
-            if "CriteriaList" in group:
-                seen = set()
-                unique_criteria = []
-                for criteria in group["CriteriaList"]:
-                    if "Criteria" in criteria:
-                        key = (criteria["Criteria"].get("CriteriaType"), 
-                              criteria["Criteria"].get("ConceptName"))
-                        if key not in seen:
-                            seen.add(key)
-                            unique_criteria.append(criteria)
-                    else:
-                        key = (criteria.get("CriteriaType"), 
-                              criteria.get("ConceptName"))
-                        if key not in seen:
-                            seen.add(key)
-                            unique_criteria.append(criteria)
-                group["CriteriaList"] = unique_criteria
-
-    return cohort_json
-
 def main():
-    pdf_path = "pdf/Establishment of ICU Mortality Risk Prediction Models with Machine Learning Algorithm MIMIC .pdf"
+    # 현재 스크립트의 디렉토리 경로
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    # PDF 파일 경로
+    pdf_path = os.path.join(current_dir, "pdf", "A novel clinical prediction model for in-hospital mortality in sepsis patients complicated by ARDS- A MIMIC IV database and external validation study.pdf")
     
     # 1. PDF에서 텍스트 추출
     extracted_text = extract_text_from_pdf(pdf_path)
     
-    # 2. 텍스트에서 terms 추출
-    terms = extract_terms_from_text(extracted_text)
-
-    # 중복 제거
-    terms = remove_duplicates_from_json(terms)
-    if not terms:
-        print("Failed to extract terms")
+    # 2. 텍스트에서 criteria 추출
+    extracted_criteria = extract_terms_from_text(extracted_text)
+    print("\n[extracted_criteria]:")
+    print(json.dumps(extracted_criteria, indent=2, ensure_ascii=False))
+    
+    if not extracted_criteria:
+        print("Failed to extract criteria")
         return
-    # 디버깅 - 추후 삭제
-    print("extracted terms:", json.dumps(terms, indent=2, ensure_ascii=False))
     
-    # 3. DB에서 concept_id 조회
-    terms_with_concepts = get_concept_ids(terms)
-    print("terms_with_concepts:", terms_with_concepts)
+    # 3. OMOP CDM JSON 구조 생성
+    cohort_json = create_cohort_json(extracted_criteria)
+    print("\n[cohort_json]:")
+    print(json.dumps(cohort_json, indent=2, ensure_ascii=False))
     
-    # 4. OMOP CDM JSON 형식으로 변환
-    cohort_json = create_omop_json(terms_with_concepts)
-    print("cohort_json:", cohort_json)
+    # 4. DB에서 concept_id 조회
+    cohort_json = get_concept_ids(cohort_json)
+    print("\n[cohort_json with concept_ids]:")
+    print(json.dumps(cohort_json, indent=2, ensure_ascii=False))
     
     # 5. JSON 파일로 저장
-    output_file = "cohort_criteria.json"
+    output_file = os.path.join(current_dir, "cohort_criteria.json")
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(cohort_json, f, indent=4, ensure_ascii=False)
-    print(f"Cohort definition saved to {output_file}")
+    print(f"\nCohort definition saved to: {output_file}")
 
 if __name__ == "__main__":
     main()

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -101,7 +101,7 @@ These keywords will be used to search for concept codes in a structured OMOP CDM
    - name: The medical term or concept name
    - exclusion: Boolean (true for exclusion criteria)
    - valueAsNumber: For measurement criteria (MANDATORY for Measurement type)
-   - age: For age criteria (optional)
+   - age: For age criteria (MANDATORY for DemographicCriteria type)
 
 2. Important:
    - [CRITICAL] Only extract criteria from sections clearly labeled as inclusion/exclusion criteria
@@ -114,15 +114,22 @@ These keywords will be used to search for concept codes in a structured OMOP CDM
    - [CRITICAL] For Measurement type:
      * MUST include valueAsNumber with operator and value
      * Example: "Hemoglobin > 13" → {{ "valueAsNumber": {{ "gt": 13 }} }}
-   - For age criteria:
-     * Use "ObservationPeriod" as type
-     * Include age value and operator
+   - [CRITICAL] For age criteria:
+     * MUST use "DemographicCriteria" as type
+     * MUST include age value and operator
+     * Example: "Age > 18" → {{ "type": "DemographicCriteria", "name": "Age", "age": {{ "gt": 18 }} }}
    - For conditions:
      * Use "ConditionOccurrence" as type (NOT ConditionEra)
 
 3. Return ONLY this exact JSON format (no other text):
 {{
   "criteria": [
+    {{
+      "type": "DemographicCriteria",
+      "name": "Age",
+      "age": {{ "gt": 18, "lt": 65 }},
+      "exclusion": false
+    }},
     {{
       "type": "ConditionOccurrence",
       "name": "Diabetes",

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -353,26 +353,31 @@ def create_cohort_json(extracted_criteria: list) -> dict:
     exclusion_containers = []
     
     for criteria in extracted_criteria:
-        # ConceptSet 생성
-        concept_set = {
-            "conceptset_id": str(concept_set_id),
-            "name": criteria["name"],
-            "items": []  # DB에서 조회 후 업데이트
-        }
-        result["conceptsets"].append(concept_set)
-        
-        # Filter 생성
-        filter_obj = {
-            "type": criteria["type"],
-            "first": True,
-            "conceptset": str(concept_set_id)
-        }
-        
-        # 추가 필터 조건
-        if criteria.get("valueAsNumber"):
-            filter_obj["valueAsNumber"] = criteria["valueAsNumber"]
         if criteria.get("age"):
-            filter_obj["age"] = criteria["age"]
+            filter_obj = {
+                "type": "DemographicCriteria",
+                "first": True,
+                "age": criteria["age"]
+            }
+        else:
+            # ConceptSet 생성
+            concept_set = {
+                "conceptset_id": str(concept_set_id),
+                "name": criteria["name"],
+                "items": []  # DB에서 조회 후 업데이트
+            }
+            result["conceptsets"].append(concept_set)
+            
+            # Filter 생성
+            filter_obj = {
+                "type": criteria["type"],
+                "first": True,
+                "conceptset": str(concept_set_id)
+            }
+            
+            # 추가 필터 조건
+            if criteria.get("valueAsNumber"):
+                filter_obj["valueAsNumber"] = criteria["valueAsNumber"]
         
         # Container 생성
         container = {
@@ -390,8 +395,9 @@ def create_cohort_json(extracted_criteria: list) -> dict:
                 container["operator"] = "AND"
             inclusion_containers.append(container)
         
-        concept_set_id += 1
-    
+        if not criteria.get("age"):  # age가 아닌 경우에만 concept_set_id 증가
+            concept_set_id += 1
+
     # cohort에 groups 추가
     if inclusion_containers:
         result["cohort"].append({

--- a/ai/query_test.py
+++ b/ai/query_test.py
@@ -11,7 +11,7 @@ clickhouse_client = Client(
 query = """
 SELECT concept_id, concept_name, domain_id
 FROM concept 
-WHERE concept_name ILIKE '%Sepsis-3%'
+WHERE concept_name ILIKE '%Acute Respiratory Distress Syndrome%'
 AND domain_id = 'Condition'
 AND invalid_reason IS NULL
 LIMIT 20;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #56 

## 📝 작업 내용

CohortDefinition 구조 개선:

포함 기준과 제외 기준을 그룹별(그룹 1: inclusion, 그룹 2: exclusion)로 구분하고, 각 그룹 내에서 컨테이너 단위로 하나의 필터(기준)를 포함하도록 수정했습니다.

각 컨테이너의 name에는 사람이 읽기 쉬운 기준명(검색어)이 들어가고, conceptset 필드에는 해당 기준과 매핑되는 숫자 형태의 ConceptSet ID를 지정하도록 변경했습니다.

예를 들어, "hemodialysis"(혈액투석) 기준은 conceptset: "0"와 같이 0부터 순서대로 지정하며, 이와 관련된 ConceptSet은 conceptsets 배열에 등록됩니다.

DB 검색 및 ConceptSet 업데이트 기능 추가:

ClickHouse를 사용하여 PDF에서 추출한 기준의 ConceptName을 기반으로 개념 정보를 조회하고, 이를 ConceptSet의 items에 업데이트하는 기능을 구현했습니다.

만약 검색 결과가 없을 경우 LLM을 활용해 검색어를 재검색하는 로직은 추후에 추가할 예정입니다.

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요. 없다면 요구사항 란은 제거해주세요.
>
> get_omop_concept_id() 함수의 Measurement 타입 처리 및 SQL 쿼리 구성에 대해 검토 부탁드립니다.


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
