### PR TITLE
Feat: Home화면 및 Footer 구현

### DIFF
--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -1,0 +1,20 @@
+<footer class="bg-white border-t border-gray-200 mt-auto">
+  <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+    <div class="flex flex-col items-center justify-center space-y-4">
+      <div class="flex items-center space-x-2">
+        <div class="h-12 flex items-center text-lg font-semibold text-gray-600">Kookmin University</div>
+        <div class="h-8 w-px bg-gray-200"></div>
+        <div class="h-12 flex items-center text-lg font-semibold text-gray-600">SNUH</div>
+      </div>
+      <div class="text-center">
+        <p class="text-sm text-gray-600">
+          A Collaborative Project between Kookmin University Capstone Design Team 16 
+          <br />and Seoul National University Hospital Institute of Convergence Medicine with Innovative Technology
+        </p>
+      </div>
+      <div class="text-xs text-gray-400">
+        © 2025 Capstone Design Team 16. All rights reserved.
+      </div>
+    </div>
+  </div>
+</footer>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -34,7 +34,7 @@
 		<div class="relative mx-auto max-w-[1280px] px-8">
 			<div class="flex">
 				<!-- 로고 영역 -->
-				<div class="w-[200px] h-[60px] flex items-center justify-center gap-2">
+				<a href="/" class="w-[200px] h-[60px] flex items-center justify-center gap-2">
 					<svg 
 						class="w-6 h-6 text-blue-600" 
 						fill="none" 
@@ -52,7 +52,7 @@
 							Bento
 						</span>
 					</p>
-				</div>
+				</a>
 
 				<!-- 메인 네비게이션 -->
 				<nav class="flex-1" aria-label="Main navigation">

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -93,6 +93,20 @@
 									Concept Sets
 								</a>
 							</div>
+
+							<!-- Person 메뉴 -->
+							<div class="w-[200px]">
+								<a 
+									href="/person"
+									role="menuitem"
+									tabindex="-1"
+									onmouseenter={() => activeMenu = 'person'}
+									class="flex items-center h-[60px] w-full px-6 text-[15px] transition-all duration-200
+										{activeMenu === 'person' ? 'text-slate-900 font-semibold' : 'text-slate-700 font-medium'} 
+										hover:text-slate-900 hover:font-semibold">
+									Person
+								</a>
+							</div>
 						</div>
 					</div>
 				</nav>
@@ -152,6 +166,19 @@
 											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
 											onmouseenter={() => activeMenu = 'concepts'}>
 											Concept Set Definition
+										</a>
+									</li>
+								</ul>
+							</div>
+
+							<!-- Person 섹션 -->
+							<div class="w-[200px] py-4 border-r border-slate-300">
+								<ul class="space-y-3">
+									<li>
+										<a href="/person" 
+											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
+											onmouseenter={() => activeMenu = 'person'}>
+											Person Search
 										</a>
 									</li>
 								</ul>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,0 +1,65 @@
+<script>
+  import { page } from "$app/stores";
+  import Footer from "$lib/components/Footer.svelte";
+</script>
+
+<div class="min-h-screen bg-gradient-to-b from-blue-50 to-white pt-[80px]">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <div class="text-center">
+      <h1 class="text-4xl font-bold text-gray-900 sm:text-5xl md:text-6xl mb-8">
+        Welcome to <span class="bg-gradient-to-r from-purple-600 via-blue-600 to-cyan-500 bg-clip-text text-transparent">Bento</span>
+      </h1>
+      <p class="text-xl text-gray-600 max-w-3xl mx-auto mb-12">
+        Explore and analyze your CDM data with powerful cohort analysis tools
+      </p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mt-12">
+      <!-- Cohort Builder Card -->
+      <a href="/cohort" class="group">
+        <div class="bg-white rounded-lg shadow-md p-6 h-full hover:shadow-lg transition-shadow border border-gray-100">
+          <div class="text-4xl mb-4">
+            👥
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+            Cohort Builder
+          </h3>
+          <p class="text-gray-600">
+            Create and manage cohorts with an intuitive interface. Define inclusion/exclusion criteria and build complex patient groups.
+          </p>
+        </div>
+      </a>
+
+      <!-- CDM Viewer Card -->
+      <a href="/concept-set" class="group">
+        <div class="bg-white rounded-lg shadow-md p-6 h-full hover:shadow-lg transition-shadow border border-gray-100">
+          <div class="text-4xl mb-4">
+            🔍
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+            CDM Viewer
+          </h3>
+          <p class="text-gray-600">
+            Browse and analyze your Common Data Model (CDM) data. Explore concept sets and understand your data structure.
+          </p>
+        </div>
+      </a>
+
+      <!-- Cohort Statistics Card -->
+      <a href="/cohort/comparison" class="group">
+        <div class="bg-white rounded-lg shadow-md p-6 h-full hover:shadow-lg transition-shadow border border-gray-100">
+          <div class="text-4xl mb-4">
+            📊
+          </div>
+          <h3 class="text-lg font-semibold text-gray-900 mb-2 group-hover:text-blue-600 transition-colors">
+            Cohort Statistics
+          </h3>
+          <p class="text-gray-600">
+            Compare and analyze cohort statistics with interactive visualizations. Get insights into demographics, conditions, drugs, and more.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+</div>
+<Footer />

--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { onMount } from "svelte";
   import { goto } from "$app/navigation";
+  import Footer from '$lib/components/Footer.svelte';
 
   let searchQuery = "";
   let searchInput = "";
@@ -291,4 +292,5 @@
       </div>
     </div>
   {/if}
+  <Footer />
 </div>

--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -277,28 +277,6 @@
     </div>
   </div>
 
-  <!-- Footer -->
-  <footer class="bg-white border-t border-gray-200 mt-auto">
-    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-      <div class="flex flex-col items-center justify-center space-y-4">
-        <div class="flex items-center space-x-2">
-          <div class="h-12 flex items-center text-lg font-semibold text-gray-600">Kookmin University</div>
-					<div class="h-8 w-px bg-gray-200"></div>
-					<div class="h-12 flex items-center text-lg font-semibold text-gray-600">SNUH</div>
-        </div>
-        <div class="text-center">
-          <p class="text-sm text-gray-600">
-            A Collaborative Project between Kookmin University Capstone Design Team 16 
-            <br />and Seoul National University Hospital Institute of Convergence Medicine with Innovative Technology
-          </p>
-        </div>
-        <div class="text-xs text-gray-400">
-          © 2025 Capstone Design Team 16. All rights reserved.
-        </div>
-      </div>
-    </div>
-  </footer>
-
   <!-- Error Message -->
   {#if errorMessage}
     <div class="fixed bottom-8 left-1/2 transform -translate-x-1/2 z-50">

--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -277,7 +277,29 @@
     </div>
   </div>
 
-  <!-- 에러 메시지 - 화면 하단 중앙에 고정 -->
+  <!-- Footer -->
+  <footer class="bg-white border-t border-gray-200 mt-auto">
+    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
+      <div class="flex flex-col items-center justify-center space-y-4">
+        <div class="flex items-center space-x-2">
+          <div class="h-12 flex items-center text-lg font-semibold text-gray-600">Kookmin University</div>
+					<div class="h-8 w-px bg-gray-200"></div>
+					<div class="h-12 flex items-center text-lg font-semibold text-gray-600">SNUH</div>
+        </div>
+        <div class="text-center">
+          <p class="text-sm text-gray-600">
+            A Collaborative Project between Kookmin University Capstone Design Team 16 
+            <br />and Seoul National University Hospital Institute of Convergence Medicine with Innovative Technology
+          </p>
+        </div>
+        <div class="text-xs text-gray-400">
+          © 2025 Capstone Design Team 16. All rights reserved.
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <!-- Error Message -->
   {#if errorMessage}
     <div class="fixed bottom-8 left-1/2 transform -translate-x-1/2 z-50">
       <div class="bg-red-50 border border-red-200 rounded-md shadow-lg px-6 py-3 text-sm text-red-600 flex items-center">

--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -1,5 +1,6 @@
 <script>
     import analysisData from '$lib/data/singleCohortAnalysisTest.json';
+    import Footer from '$lib/components/Footer.svelte';
 </script>
 
 <div class="pl-4 pr-4">
@@ -36,6 +37,12 @@
             </div>
         </div>
     </div>
-
-    (코호트 구성에 대한 내용 추가 예정)
 </div>
+
+    <!-- 메인 컨텐츠 영역 -->
+    <div class="flex-1 overflow-y-auto">
+        <div class="p-6">
+            (코호트 구성에 대한 내용 추가 예정)
+        </div>
+        <Footer />
+    </div>

--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -10,6 +10,7 @@
     import Specimen from "$lib/components/Table/Specimen.svelte";
     import BioSignal from "$lib/components/Table/BioSignal.svelte";
     import * as d3 from "d3";
+    import Footer from '$lib/components/Footer.svelte';
 
     import analysisData from '$lib/data/patientAnalysisTest.json';
     import ChartCard from '$lib/components/ChartCard.svelte';
@@ -543,6 +544,7 @@
             {/each}
         {/if}
     {/if}
+    <Footer />
 </div>
 
 <style>

--- a/frontend/src/routes/cohort/[cohortID]/analysis/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/analysis/+page.svelte
@@ -11,7 +11,7 @@
     import BarChart from "$lib/components/Charts/BarChart/BarChart.svelte"
     import BarChartWrapper from "$lib/components/Charts/BarChart/BarChartWrapper.svelte"
     import BarChartTableView from '$lib/components/Charts/BarChart/BarChartTableView.svelte';
-
+    import Footer from '$lib/components/Footer.svelte';
     let activeTab = 'default'; // 탭 활성화 상태 관리
 
     let isTableView = {
@@ -306,9 +306,8 @@
             </div>
         </div>
     {/if}
-    
 </div>
-
+<Footer />
 
 <style>
     .tab {

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -14,7 +14,8 @@
   import { transformTopTenData } from "$lib/components/Charts/StackedBarChart/topTenChartTransformer.js";
   import StackedBarChartWrapper from "$lib/components/Charts/StackedBarChart/StackedBarChartWrapper.svelte";
   import StackedBarChartTableView from "$lib/components/Charts/StackedBarChart/StackedBarChartTableView.svelte";
-  
+  import Footer from '$lib/components/Footer.svelte';
+
   // 코호트 데이터
   let selectedCohorts = []; // 선택된 코호트들 ID 배열
   let cohortData = []; // 코호트 데이터
@@ -531,9 +532,9 @@
       </div>
     </div>
 
-    <!-- 차트 그리드 -->
-    <div class="flex-1 overflow-y-auto p-6">
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+    <!-- 차트 그리드 및 Footer -->
+    <div class="flex-1 overflow-y-auto">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 p-6">
         {#if selectItems[0].checked}
           <ChartCard 
             title="Gender Ratio" 
@@ -858,8 +859,8 @@
           </ChartCard>
         {/if}
       </div>
+      <Footer />
     </div>
   </div>
 </div>
-
 <svelte:window on:click={handleClickOutside} /> 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#70 #65 


## 📝 작업 내용

홈화면과 Footer를 구현했습니다. 메뉴에는 Person 을 추가했습니다.

### 스크린샷
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/095864e7-0cbf-4584-b73a-8b12a01eb079" />


## 💬 리뷰 요구사항(선택)
홈화면은 우선 초기 홈화면으로 생각해주시면 될 것 같습니다. 세부 내용들과 url연결되는 버튼들은 이후 조정이 필요합니다.
Footer는 모든 페이지의 형태가 동일하지 않아(일부 페이지에 사이드바 존재) 최상단의 layout.svelte에 배치가 불가했습니다. 모든 페이지의 적용을 위해 각각의 페이지에서 컴포넌트 Footbar를 적절하게 불러와 사용하는 방식으로 변경했습니다.


## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
