### PR TITLE
Feat: 코호트 기준 추출 및 사용자 피드백 반영을 위한 플로우 구현

### DIFF
--- a/ai/get_omop_concept_id.py
+++ b/ai/get_omop_concept_id.py
@@ -1,0 +1,129 @@
+import re
+import os
+from dotenv import load_dotenv
+from clickhouse_driver import Client
+import cohort_json_schema
+
+# 환경 변수 로드
+load_dotenv()
+clickhouse_host = os.environ.get('CLICKHOUSE_HOST')
+clickhouse_database = os.environ.get('CLICKHOUSE_DATABASE')
+clickhouse_user = os.environ.get('CLICKHOUSE_USER')
+clickhouse_password = os.environ.get('CLICKHOUSE_PASSWORD')
+
+# ClickHouse 클라이언트 초기화
+clickhouse_client = Client(
+    host=clickhouse_host,
+    database=clickhouse_database,
+    user=clickhouse_user, 
+    password=clickhouse_password
+)
+
+# 불필요한 정보가 추가된 문구를 제거하는 함수 
+def clean_term(term):
+    return re.sub(r"\s*\(.*?\)", "", term).strip() 
+
+# ClickHouse에서 concept 정보 조회
+def get_omop_concept_id(term: str, domain_id: str) -> list:
+    cleaned_term = clean_term(term)
+    
+    query = """
+    SELECT 
+        concept_id,
+        concept_name,
+        domain_id,
+        vocabulary_id,
+        concept_class_id,
+        standard_concept,
+        concept_code,
+        valid_start_date,
+        valid_end_date,
+        invalid_reason
+    FROM concept 
+    WHERE concept_name ILIKE %(term)s
+    AND domain_id = %(domain_id)s 
+    AND invalid_reason IS NULL
+    LIMIT 3
+    """
+    
+    results = clickhouse_client.execute(query, {'term': f'%{cleaned_term}%', 'domain_id': domain_id})
+    
+    # Concept 객체로 변환
+    concepts = []
+    for result in results:
+        concept = {
+            "concept_id": str(result[0]),  # Identifier는 string
+            "concept_name": result[1],
+            "domain_id": result[2],
+            "vocabulary_id": result[3],
+            "concept_class_id": result[4],
+            "standard_concept": result[5],
+            "concept_code": result[6],
+            "valid_start_date": result[7].strftime("%Y-%m-%d") if result[7] else None,  # date를 문자열로 변환
+            "valid_end_date": result[8].strftime("%Y-%m-%d") if result[8] else None,    # date를 문자열로 변환
+            "invalid_reason": result[9],
+            "includeDescendants": True,  # 기본값 설정
+            "includeMapped": True
+        }
+        concepts.append(concept)
+    
+    return concepts
+
+# concept_set_id에 해당하는 filter의 type을 찾아 domain_id를 반환
+def get_concept_set_domain_id(cohort_json: dict, concept_set_id: str) -> str:
+    for group in cohort_json.get("cohort", []):
+        for container in group.get("containers", []):
+            for filter_obj in container.get("filters", []):
+                if filter_obj.get("conceptset") == concept_set_id:
+                    criteria_type = filter_obj["type"]
+                    criteria_info = cohort_json_schema.map_criteria_info(criteria_type)
+                    if criteria_info:
+                        return criteria_info["Domain_id"]
+    return None
+
+# concept_set의 items를 DB에서 조회한 결과로 업데이트
+def update_concept_set_items(concept_set: dict, domain_id: str) -> dict:
+    if not domain_id:
+        return concept_set
+        
+    concept_results = get_omop_concept_id(concept_set["name"], domain_id)
+    if concept_results:
+        concept_set["items"] = concept_results
+    return concept_set
+
+# cohort_json의 conceptset에서 concept_id를 조회하여 업데이트
+def get_concept_ids(cohort_json: dict) -> dict:
+    for concept_set in cohort_json.get("conceptsets", []):
+        if "name" in concept_set and "conceptset_id" in concept_set:
+            domain_id = get_concept_set_domain_id(cohort_json, concept_set["conceptset_id"])
+            concept_set = update_concept_set_items(concept_set, domain_id)
+    
+    return cohort_json
+
+# 테스트용 함수
+def test_concept_search(term: str, domain_id: str):
+    """
+    주어진 용어와 도메인 ID로 개념을 검색하고 결과를 출력하는 테스트 함수
+    """
+    concepts = get_omop_concept_id(term, domain_id)
+    if concepts:
+        print(f"'{term}' 검색 결과 ({len(concepts)}개):")
+        for concept in concepts:
+            print(f"Concept ID: {concept['concept_id']}")
+            print(f"Concept Name: {concept['concept_name']}")
+            print(f"Domain: {concept['domain_id']}")
+            print(f"Vocabulary: {concept['vocabulary_id']}")
+            print(f"Class: {concept['concept_class_id']}")
+            print(f"Standard: {concept['standard_concept']}")
+            print(f"Code: {concept['concept_code']}")
+            print("---")
+    else:
+        print(f"'{term}' 검색 결과가 없습니다.")
+
+# 메인 실행 부분
+if __name__ == "__main__":
+    # 테스트 예제
+    print("===== 검색 테스트 =====")
+    test_concept_search("Sepsis", "Condition")
+    test_concept_search("Diabetes Mellitus", "Condition")
+    test_concept_search("Hemoglobin", "Measurement") 

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -192,16 +192,11 @@ def extract_terms_from_text(text: str) -> list:
     llm_response = response.choices[0].message.content
     
     try:
-        # 응답에서 리스트 부분만 추출
         content = llm_response.strip()
         
-        # Markdown 코드 블록 제거
         if "```" in content:
             content = content.split("```")[1].strip()
-            print("\n[``` 마크다운 블록 제거 후]:")
-            print(content)
         
-        # LLM 응답을 JSON으로 변환
         cohort_json = json.loads(content)
 
         criteria_list = []

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -1,5 +1,6 @@
 import cohort_json_schema as cohort_json_schema
 from pdf_to_text import extract_cohort_definition_from_pdf
+from get_omop_concept_id import clean_term, get_omop_concept_id, get_concept_set_domain_id, update_concept_set_items, get_concept_ids
 
 import os
 import re
@@ -183,7 +184,6 @@ Original Term: "{term}"
 # 2. 키워드 검색어 + type 자동 추출
 def extract_terms_from_text(text: str) -> list:
     
-    
     response = client.chat.completions.create(
         model=model_name,
         messages=[{"role": "system", "content": COHORT_EXTRACTION_SYSTEM_PROMPT},
@@ -228,87 +228,6 @@ def extract_terms_from_text(text: str) -> list:
         import traceback
         print(f"Traceback: {traceback.format_exc()}")
         return []
-
-# 불필요한 정보가 추가된 문구를 제거하는 함수 
-def clean_term(term):
-    return re.sub(r"\s*\(.*?\)", "", term).strip() 
-
-# 3. ClickHouse에서 concept 정보 조회
-def get_omop_concept_id(term: str, domain_id: str) -> list:
-    cleaned_term = clean_term(term).replace('%', '%%')
-    
-    query = """
-    SELECT 
-        concept_id,
-        concept_name,
-        domain_id,
-        vocabulary_id,
-        concept_class_id,
-        standard_concept,
-        concept_code,
-        valid_start_date,
-        valid_end_date,
-        invalid_reason
-    FROM concept 
-    WHERE concept_name ILIKE %(term)s 
-    AND domain_id = %(domain_id)s 
-    AND invalid_reason IS NULL
-    LIMIT 3
-    """
-    
-    results = clickhouse_client.execute(query, {'term': f'%{cleaned_term}%', 'domain_id': domain_id})
-    
-    # Concept 객체로 변환
-    concepts = []
-    for result in results:
-        concept = {
-            "concept_id": str(result[0]),  # Identifier는 string
-            "concept_name": result[1],
-            "domain_id": result[2],
-            "vocabulary_id": result[3],
-            "concept_class_id": result[4],
-            "standard_concept": result[5],
-            "concept_code": result[6],
-            "valid_start_date": result[7].strftime("%Y-%m-%d") if result[7] else None,  # date를 문자열로 변환
-            "valid_end_date": result[8].strftime("%Y-%m-%d") if result[8] else None,    # date를 문자열로 변환
-            "invalid_reason": result[9],
-            "includeDescendants": True,  # 기본값 설정
-            "includeMapped": True
-        }
-        concepts.append(concept)
-    
-    return concepts
-
-# concept_set_id에 해당하는 filter의 type을 찾아 domain_id를 반환
-def get_concept_set_domain_id(cohort_json: dict, concept_set_id: str) -> str:
-    for group in cohort_json.get("cohort", []):
-        for container in group.get("containers", []):
-            for filter_obj in container.get("filters", []):
-                if filter_obj.get("conceptset") == concept_set_id:
-                    criteria_type = filter_obj["type"]
-                    criteria_info = cohort_json_schema.map_criteria_info(criteria_type)
-                    if criteria_info:
-                        return criteria_info["Domain_id"]
-    return None
-
-# concept_set의 items를 DB에서 조회한 결과로 업데이트
-def update_concept_set_items(concept_set: dict, domain_id: str) -> dict:
-    if not domain_id:
-        return concept_set
-        
-    concept_results = get_omop_concept_id(concept_set["name"], domain_id)
-    if concept_results:
-        concept_set["items"] = concept_results
-    return concept_set
-
-# cohort_json의 conceptset에서 concept_id를 조회하여 업데이트
-def get_concept_ids(cohort_json: dict) -> dict:
-    for concept_set in cohort_json.get("conceptsets", []):
-        if "name" in concept_set and "conceptset_id" in concept_set:
-            domain_id = get_concept_set_domain_id(cohort_json, concept_set["conceptset_id"])
-            concept_set = update_concept_set_items(concept_set, domain_id)
-    
-    return cohort_json
 
 # 4. 검색어 변경하여 재검색
 def refine_search_query(term) -> str:

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -320,7 +320,6 @@ def main():
     pdf_path = os.path.join(current_dir, "pdf", "A novel clinical prediction model for in-hospital mortality in sepsis patients complicated by ARDS- A MIMIC IV database and external validation study.pdf")
     
     # 1. PDF에서 텍스트 추출
-    # extracted_text = extract_text_from_pdf(pdf_path)
     implementable_text, non_implementable_text = extract_cohort_definition_from_pdf(pdf_path)
     
     print("\n[Implementable Criteria 부분만]:")

--- a/ai/pdf_to_text.py
+++ b/ai/pdf_to_text.py
@@ -1,0 +1,157 @@
+import pymupdf
+from openai import OpenAI
+from dotenv import load_dotenv
+import os
+
+load_dotenv()
+openai_api_key = os.environ.get('OPENAI_API_KEY')
+openai_api_base = "https://api.lambdalabs.com/v1"
+model_name = os.environ.get('LLM_MODEL')
+client = OpenAI(
+    api_key=openai_api_key,
+    base_url=openai_api_base,
+)
+
+# 1. PDF에서 텍스트 추출
+def extract_text_from_pdf(pdf_path) -> str:
+    doc = pymupdf.open(pdf_path)
+    text = ""
+    for page in doc:
+        text += page.get_text() + "\n"
+    return text
+
+# PDF에서 코호트 정의를 추출하여 text로 반환합니다.
+def extract_cohort_definition_from_pdf(pdf_path):
+    # PDF에서 텍스트 추출
+    text = extract_text_from_pdf(pdf_path)
+    
+    # 코호트 추출 프롬프트 생성
+    formatted_input = f"""
+    Input Text:
+    {text}
+    """
+    
+    # 코호트 추출을 위한 프롬프트
+    cohort_prompt = f"""
+    You are an expert in extracting cohort definitions (inclusion and exclusion criteria) from clinical documents and mapping them to OMOP CDM compatible format.
+    Please identify and organize the patient inclusion criteria and exclusion criteria from the given text.
+
+    IMPORTANT: Cohort criteria (inclusion and exclusion) are typically grouped together in specific sections or paragraphs. Look for sections labeled with terms like "Eligibility Criteria", "Selection Criteria", "Inclusion/Exclusion Criteria", etc. Focus on these complete sections rather than trying to piece together criteria from separate parts of the document.
+
+    CRITICAL: Each criterion must be listed separately on its own line. If a single line contains multiple conditions (e.g., "Patients diagnosed with sepsis-3 and ARDS"), split it into separate criteria (e.g., "Patients diagnosed with sepsis-3" and "Patients diagnosed with ARDS"). Never combine multiple medical conditions in a single criterion.
+
+    Based on the OMOP CDM schema, you should categorize the criteria into two groups:
+    1. Criteria that can be implemented in OMOP CDM
+    2. Criteria that cannot be directly implemented in OMOP CDM
+
+    The following types of criteria CAN be implemented in OMOP CDM:
+    - Demographics (age, gender, race, ethnicity)
+    - Diagnoses/conditions (using condition_occurrence, condition_era)
+    - Medications/drugs (using drug_exposure, drug_era, dose_era)
+    - Procedures (using procedure_occurrence)
+    - Lab measurements with specific values (using measurement)
+    - Visits/encounters (using visit_occurrence)
+    - Observations (using observation)
+    - Death (using death)
+    - Device exposures (using device_exposure)
+    - Specific time periods or durations that can be calculated
+
+    The following types of criteria CANNOT be directly implemented in OMOP CDM:
+    - Subjective assessments without clear definitions
+    - Complex clinical reasoning that requires human judgment
+    - Criteria based on unstructured data (e.g., physician notes interpretation)
+    - Free text descriptions that cannot be mapped to standard concepts
+    - Patient-reported outcomes not captured in structured data
+    - Criteria requiring non-EHR data sources (e.g., specialized registry data)
+    - Complex temporal relationships that cannot be expressed in the CDM
+
+    When handling medical terminology:
+    1. Preserve the original medical terms as written in the document.
+    2. [CRITICAL] If abbreviations are used, you MUST expand them to their full medical terms.
+       This is the MOST IMPORTANT rule - always expand all medical abbreviations.
+       Examples:
+       * "ESA" → "Erythropoiesis Stimulating Agent "
+       * "CKD" → "Chronic Kidney Disease"
+       * "HTN" → "Hypertension"
+       * "DM" → "Diabetes Mellitus"
+       * "CHF" → "Congestive Heart Failure"
+       * "MI" → "Myocardial Infarction"
+       * "ESRD" → "End Stage Renal Disease"
+       * "CAD" → "Coronary Artery Disease"
+       * "T2DM" → "Type 2 Diabetes Mellitus"
+       * "COPD" → "Chronic Obstructive Pulmonary Disease"
+       * "AKI" → "Acute Kidney Injury"
+    3. Keep specific measurements and thresholds exactly as stated (e.g., "Hemoglobin value more than 13 g/dL").
+    4. Maintain the original context of each criterion.
+    5. For vague or overly specific medical terms, consider using standard medical terminology while preserving the original meaning.
+       Example: "Sodium bicarbonate therapy" → "Sodium bicarbonate"
+
+    Your response MUST follow this format:
+
+    Implementable Criteria
+    Inclusion Criteria
+    1. [First implementable inclusion criterion]
+    2. [Second implementable inclusion criterion]
+    ...
+    
+    Exclusion Criteria
+    1. [First implementable exclusion criterion]
+    2. [Second implementable exclusion criterion]
+    ...
+    
+    Non-implementable Criteria
+    Inclusion Criteria
+    1. [First non-implementable inclusion criterion]
+    2. [Second non-implementable inclusion criterion]
+    ...
+    
+    Exclusion Criteria
+    1. [First non-implementable exclusion criterion]
+    2. [Second non-implementable exclusion criterion]
+    ...
+
+    If there are no criteria in any section, write "None identified." in that section.
+
+    Here's an example of what your output might look like:
+
+    Implementable Criteria
+    Inclusion Criteria
+    1. Patients who are 20 years old or older.
+    2. Patients with hemodialysis (HD).
+    3. Patients using Erythropoiesis Stimulating Agent therapy for at least three months.
+    4. Patients with iron deficiency anemia.
+
+    Exclusion Criteria
+    1. Patients in intensive care unit.
+    2. Patients with hemoglobin value more than 13 g/dL.
+    3. Kidney transplant patients.
+    
+    Non-implementable Criteria
+    Inclusion Criteria
+    1. First intensive care unit admission.
+    
+    Exclusion Criteria
+    1. Patients with sepsis or active infections. (Requires specific definition of "active infections")
+    2. An ICU stay duration of less than 24 hours.
+
+    Here is the text to analyze:
+    {formatted_input}
+    """
+    
+    response = client.chat.completions.create(
+        model=model_name,
+        messages=[
+            {"role": "system", "content": "You are an expert in extracting cohort definitions (inclusion and exclusion criteria) from clinical documents. Focus on finding complete sections of criteria rather than isolated mentions."},
+            {"role": "user", "content": cohort_prompt}
+        ]
+    )
+    
+    content = response.choices[0].message.content
+    
+    # "## Non-implementable Criteria"를 기준으로 텍스트 분리
+    parts = content.split("Non-implementable Criteria")
+    implementable_text = parts[0].strip() if len(parts) > 0 else ""
+    non_implementable_text = ("Non-implementable Criteria" + parts[1].strip()) if len(parts) > 1 else ""
+    
+    return implementable_text, non_implementable_text
+

--- a/ai/pdf_to_text.py
+++ b/ai/pdf_to_text.py
@@ -148,7 +148,7 @@ def extract_cohort_definition_from_pdf(pdf_path):
     
     content = response.choices[0].message.content
     
-    # "## Non-implementable Criteria"를 기준으로 텍스트 분리
+    # "Non-implementable Criteria"를 기준으로 텍스트 분리
     parts = content.split("Non-implementable Criteria")
     implementable_text = parts[0].strip() if len(parts) > 0 else ""
     non_implementable_text = ("Non-implementable Criteria" + parts[1].strip()) if len(parts) > 1 else ""

--- a/ai/query_test.py
+++ b/ai/query_test.py
@@ -8,10 +8,28 @@ clickhouse_client = Client(
 )
 
 # 단어 검색 쿼리
+# query = """
+# SELECT concept_id, concept_name, domain_id
+# FROM concept 
+# WHERE concept_name ILIKE '%sepsis%'
+# AND domain_id = 'Condition'
+# AND invalid_reason IS NULL
+# LIMIT 20;
+# """
 query = """
-SELECT concept_id, concept_name, domain_id
+SELECT 
+    concept_id,
+    concept_name,
+    domain_id,
+    vocabulary_id,
+    concept_class_id,
+    standard_concept,
+    concept_code,
+    valid_start_date,
+    valid_end_date,
+    invalid_reason
 FROM concept 
-WHERE concept_name ILIKE '%Acute Respiratory Distress Syndrome%'
+WHERE concept_name ILIKE 'sepsis'
 AND domain_id = 'Condition'
 AND invalid_reason IS NULL
 LIMIT 20;

--- a/ai/query_test.py
+++ b/ai/query_test.py
@@ -17,30 +17,79 @@ clickhouse_client = Client(
 # LIMIT 20;
 # """
 query = """
-SELECT 
-    concept_id,
-    concept_name,
-    domain_id,
-    vocabulary_id,
-    concept_class_id,
-    standard_concept,
-    concept_code,
-    valid_start_date,
-    valid_end_date,
-    invalid_reason
-FROM concept 
-WHERE concept_name ILIKE 'sepsis'
-AND domain_id = 'Condition'
-AND invalid_reason IS NULL
-LIMIT 20;
+WITH limited_concepts AS
+(
+    SELECT
+        concept_id,
+        concept_name,
+        domain_id,
+        vocabulary_id,
+        concept_class_id,
+        standard_concept,
+        concept_code,
+        valid_start_date,
+        valid_end_date,
+        invalid_reason
+    FROM concept
+    WHERE (concept_name ILIKE '%sepsis%') AND (domain_id = 'Condition') AND (invalid_reason IS NULL)
+)
+SELECT
+    lc.concept_id,
+    lc.concept_name,
+    lc.domain_id,
+    lc.vocabulary_id,
+    lc.concept_class_id,
+    lc.standard_concept,
+    lc.concept_code,
+    lc.valid_start_date,
+    lc.valid_end_date,
+    lc.invalid_reason,
+    COALESCE(pc.parent_count, 0) AS parent_count,
+    COALESCE(cc.child_count, 0) AS child_count
+FROM limited_concepts AS lc
+LEFT JOIN
+(
+    SELECT
+        descendant_concept_id AS concept_id,
+        COUNT(*) AS parent_count
+    FROM concept_ancestor
+    WHERE descendant_concept_id IN (
+        SELECT concept_id
+        FROM limited_concepts
+    )
+    GROUP BY descendant_concept_id
+) AS pc ON lc.concept_id = pc.concept_id
+LEFT JOIN
+(
+    SELECT
+        ancestor_concept_id AS concept_id,
+        COUNT(*) AS child_count
+    FROM concept_ancestor
+    WHERE ancestor_concept_id IN (
+        SELECT concept_id
+        FROM limited_concepts
+    )
+    GROUP BY ancestor_concept_id
+) AS cc ON lc.concept_id = cc.concept_id
+ORDER BY child_count DESC
 """
 
 try:
     results = clickhouse_client.execute(query)
     if results:
-        print("검색 결과 : ")
-        for row in results:
-            print(f"Concept ID: {row[0]}, Concept Name: {row[1]}, Domain: {row[2]}")
+        # 결과가 많으면 10개만 표시
+        display_count = min(10, len(results))
+        print(f"검색 결과 (전체 {len(results)}개 중 {display_count}개 표시): ")
+        print(f"자식 수가 많은 순으로 정렬됨")
+        print("=" * 80)
+        for i in range(display_count):
+            row = results[i]
+            print(f"Concept ID: {row[0]}")
+            print(f"Concept Name: {row[1]}")
+            print(f"Domain: {row[2]}, Vocabulary: {row[3]}, Class: {row[4]}, Standard: {row[5]}")
+            print(f"Code: {row[6]}")
+            print(f"부모 개념 수: {row[10]} | 자식 개념 수: {row[11]}")
+            print("=" * 80)
     else:
         print("검색 결과 없음")
 except Exception as e:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #79 

## 📝 작업 내용

> pdf 업로드 후 코호트 기준을 텍스트로 사용자에게 띄워준 후, 사용자가 코호트 기준에 대해서 직접 수정할 수 있도록 하여 초기부터 정확한 기준으로 찾도록 기능을 구현했습니다. 사용자가 피드백 후 다시 llm을 통해 DB에서 해당 코호트 아이디를 찾아 Json으로 최종 구성합니다.
사용자가 보고 직접 수정하는 부분은 프론트에 띄운 후 다시 텍스트로 받아올 예정이라 아직 직접 수정은 하지 않는 것으로 코드가 구현되어있습니다. 

> 전체 플로우:
  pdf 업로드 -> 코호트 기준 텍스트로 추출(이 때 사용자가 피드백을 줄 예정) -> llm에게 수정된 코호트 텍스트 전달 -> DB검색 -> 최종 Json 구성

> 현재는 코호트 기준 텍스트로 추출 후 피드백 없이 바로 llm에게 코호트 택스트 전달합니다.

> 또한 DB 검색 시 가장 상위의 개념이나 큰 개념을 먼저 사용자에게 띄우기 위해 자식 수, 부모 수를 계산하여 자식 수가 가장 많은 순으로 정렬되도록 구성하도록 수정하였습니다.

### 스크린샷 (선택)

## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
