### PR TITLE
Design: 개별 환자 페이지 리팩토링

### DIFF
--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -97,21 +97,28 @@
 	</div>
 
 	<div class="flex w-full px-2 py-2">
-		<input
-			type="text"
-			class="h-8 w-full rounded-sm border border-zinc-200 bg-zinc-50 text-left shadow-sm placeholder:text-xs text-xs"
-			placeholder="Enter Person ID"
-			bind:value={searchQuery}
-			onkeydown={(e) => {
-				if(e.key === "Enter") filterData();
-			}}
-		/>
-		<button onclick={filterData} aria-label="Search-Person-ID">
-			<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-8 h-8">
-				<path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
-			</svg>
-		</button>
+		<div class="relative flex-1">
+			<input
+				type="text"
+				class="h-8 w-full rounded-lg border border-zinc-200 bg-white pl-3 pr-9 text-xs transition-colors placeholder:text-gray-400 hover:border-zinc-300 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				placeholder="Enter Person ID"
+				bind:value={searchQuery}
+				onkeydown={(e) => {
+					if(e.key === "Enter") filterData();
+				}}
+			/>
+			<button 
+				onclick={filterData} 
+				aria-label="Search-Person-ID"
+				class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-blue-600 transition-colors"
+			>
+				<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+					<path stroke-linecap="round" stroke-linejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />
+				</svg>
+			</button>
+		</div>
 	</div>
+
 	<div class="h-[100vh] w-full px-2" bind:this={cohortDiv}>
 		<div class="flex flex-col rounded-sm border-r border-t border-l border-zinc-200 bg-zinc-50 max-h-full overflow-y-auto">
 			{#each paginatedData as user}

--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -120,23 +120,57 @@
 	</div>
 
 	<div class="h-[100vh] w-full px-2" bind:this={cohortDiv}>
-		<div class="flex flex-col rounded-sm border-r border-t border-l border-zinc-200 bg-zinc-50 max-h-full overflow-y-auto">
+		<!-- 환자 목록 -->
+		<div class="flex flex-col rounded-lg border border-zinc-200 bg-white max-h-full overflow-y-auto shadow-sm">
 			{#each paginatedData as user}
-				<a href="/cohort/{cohortID}/{user.personid}">
-					<button class="w-full border-b border-zinc-200 px-2 py-2 text-left text-xs overflow-wrap">
-						{user.gender} ({user.age}) | {user.personid}
-					</button>
+				<a href="/cohort/{cohortID}/{user.personid}" class="group transition-colors duration-200 hover:bg-zinc-50">
+					<div class="flex items-center justify-between px-4 py-2 border-b border-zinc-100 h-[33px]">
+						<div class="flex items-center w-full">
+							<span class="text-xs text-zinc-400 w-[70px]">ID {user.personid}</span>
+							<span class="text-xs text-zinc-600">{user.gender}</span>
+							<span class="text-xs text-zinc-300 mx-1">•</span>
+							<span class="text-xs text-zinc-600">{user.age}세</span>
+						</div>
+						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3.5 h-3.5 text-zinc-400 opacity-0 group-hover:opacity-100 transition-opacity">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+						</svg>
+					</div>
 				</a>
 			{/each}
 		</div>
-
-		<!-- Pagination -->
-		<div class="flex justify-between px-2 py-2 text-xs">
-			<button onclick={prevPage} disabled={currentPage === 1} class="text-blue-600 disabled:text-gray-300">{"<"}</button>
-			<span>Page {currentPage} / {Math.ceil((filteredData.length ? filteredData.length : 1) / itemsPerPage)}</span>
-			<button onclick={nextPage} disabled={currentPage * itemsPerPage >= filteredData.length} class="text-blue-600 disabled:text-gray-300">{">"}</button>
+	
+		<!-- 페이지네이션 -->
+		<div class="flex justify-center items-center gap-6 py-3">
+			<button
+				aria-label="Previous-Page"
+				onclick={prevPage}
+				disabled={currentPage === 1}
+				class="p-2 text-sm font-medium transition-colors"
+				class:text-gray-400={currentPage === 1}
+				class:text-blue-600={currentPage !== 1}
+				class:hover:text-blue-800={currentPage !== 1}
+			>
+				‹
+			</button>
+	
+			<span class="text-xs text-zinc-600">
+				{currentPage} / {Math.ceil((filteredData.length || 1) / itemsPerPage)}
+			</span>
+	
+			<button
+				aria-label="Next-Page"
+				onclick={nextPage}
+				disabled={currentPage * itemsPerPage >= filteredData.length}
+				class="p-2 text-sm font-medium transition-colors"
+				class:text-gray-400={currentPage * itemsPerPage >= filteredData.length}
+				class:text-blue-600={currentPage * itemsPerPage < filteredData.length}
+				class:hover:text-blue-800={currentPage * itemsPerPage < filteredData.length}
+			>
+				›
+			</button>
 		</div>
 	</div>
+	
 </div>
 
 <div class="relative left-[200px] px-6 w-[calc(100%-206px)]">

--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -150,7 +150,9 @@
             .append("svg")
             .attr("width", width)
             .attr("height", height)
-            .style("border", "1px solid black");
+            .style("border", "1px solid #d1d5db")
+            .style("border-radius", "6px")
+            .style("box-shadow", "0 1px 3px rgba(0, 0, 0, 0.1)");
         }
         svg.selectAll("*").remove();
         return svg;
@@ -354,11 +356,14 @@
 <header class="py-4 bg-white border-b w-full">
     <div class="flex justify-between py-2">
         <div class="flex items-center px-[10px] py-[5px] whitespace-nowrap">
-            <span class="info"><strong>ID : </strong> {personTable.person_id}</span>
-            <span class="divider">|</span>
-            <span class="info"><strong>Gender : </strong> {genderCodes[personTable.gender_concept_id]}</span>
-            <span class="divider">|</span>
-            <span class="info"><strong>Date : </strong> {personTable.year_of_birth}.{personTable.month_of_birth}.{personTable.day_of_birth}</span>
+            <span class="text-sm text-gray-400">ID</span>
+            <span class="text-sm font-medium text-gray-900 ml-1">{personTable.person_id}</span>
+            <span class="text-gray-200 mx-3">|</span>
+            <span class="text-sm text-gray-400">Gender</span>
+            <span class="text-sm font-medium text-gray-900 ml-1">{genderCodes[personTable.gender_concept_id]}</span>
+            <span class="text-gray-200 mx-3">|</span>
+            <span class="text-sm text-gray-400">Birth</span>
+            <span class="text-sm font-medium text-gray-900 ml-1">{personTable.year_of_birth}.{personTable.month_of_birth}.{personTable.day_of_birth}</span>
         </div>
         <div class="flex rounded-full border border-gray-200 p-0.5 bg-gray-50 absolute right-14 top-6">
             <button 
@@ -377,7 +382,7 @@
 <div class="pt-8 pb-[60px] flex flex-col gap-5">
     {#if !isStatisticsView}
         <div class="w-full">
-            <div class="grid grid-cols-2 gap-4">
+            <div class="grid grid-cols-6 gap-4">
                 <ChartCard
                     title="Visit Type Ratio"
                     description="The ratio of visits by visit type."
@@ -546,17 +551,3 @@
     {/if}
     <Footer />
 </div>
-
-<style>
-    .info {
-        font-weight: normal;
-        font-size: 1.1rem;
-        margin: 0 8px;
-    }
-
-    .divider {
-        color: #888;
-        font-weight: bold;
-        margin: 0 8px;
-    }
-</style>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#84 

## 📝 작업 내용
개별 환자 페이지의 사이드바, 개별 환자 통계 페이지의 디자인을 개선하였습니다.

### 스크린샷 (선택)
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/05e49494-4ffd-44ed-af56-6f97e3ffc5c0" />

</br>
</br>
<img width="199" alt="image" src="https://github.com/user-attachments/assets/24e47aba-61dd-44c6-bfa4-4b80d92dd3f2" />
</br>
환자 목록 호버 시 이렇게 화살표가 나옵니다.


## 💬 리뷰 요구사항(선택)
CDM 데이터 뷰어 화면은 아직 수정이 필요할 것 같아 건들지 않았습니다.

## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
