### PR TITLE
Feat: demographic 순서 수정 & 구조화 기준 추출과 JSON 변환 부분 통합

### DIFF
--- a/ai/cohort_json_schema.py
+++ b/ai/cohort_json_schema.py
@@ -21,33 +21,7 @@ const cohortExample: CohortDefinition = {
     {
       conceptset_id: "0",
       name: "Hemodialysis",
-      type: "ProcedureOccurrence",
-      items: [
-        {
-          concept_id: "101",
-          concept_name: "Hemodialysis",
-          domain_id: "Procedure",
-          vocabulary_id: "OMOP",
-          concept_class_id: "Procedure",
-          standard_concept: "S",
-          concept_code: "HD01",
-          valid_start_date: "2000-01-01",
-          valid_end_date: "2099-12-31",
-          invalid_reason: ""
-        },
-        {
-          concept_id: "102",
-          concept_name: "Hemodialysis2",
-          domain_id: "Procedure",
-          vocabulary_id: "OMOP",
-          concept_class_id: "Procedure",
-          standard_concept: "S",
-          concept_code: "HD02",
-          valid_start_date: "2000-01-01",
-          valid_end_date: "2099-12-31",
-          invalid_reason: ""
-        }
-      ]
+      items: []
     }
     // 추가 conceptset 항목이 있으면 여기에 추가합니다.
   ],
@@ -90,8 +64,22 @@ const cohortExample: CohortDefinition = {
         }
       ]
     },
+    {// Group 2: Demographic Criteria
+      containers: [
+        {
+          name: "age",
+          filters: [
+            {
+              type: "demographic",
+              first: true,
+              age: { gte: 20 }
+            }
+          ]
+        }
+      ]
+    },
     {
-      // Group 2: Exclusion Criteria
+      // Group 3: Exclusion Criteria
       not: true,
       containers: [
         {

--- a/ai/cohort_json_schema.py
+++ b/ai/cohort_json_schema.py
@@ -532,67 +532,63 @@ def map_criteria_info(criteria_type):
     CriteriaType을 Domain_id(clickhouse 도메인)와 type(OMOP CDM type)으로 매핑
     """
     criteria_info = {
-        "ConditionEra": {
-            "Domain_id": "Condition",
-            "type": "condition_era"
-        },
-        "ConditionOccurrence": {
+        "condition_occurrence": {
             "Domain_id": "Condition",
             "type": "condition_occurrence"
         },
-        "Death": {
+        "death": {
             "Domain_id": "Death",
             "type": "death"
         },
-        "DeviceExposure": {
+        "device_exposure": {
             "Domain_id": "Device",
             "type": "device_exposure"
         },
-        "DoseEra": {
+        "dose_era": {
             "Domain_id": "Drug",
             "type": "dose_era"
         },
-        "DrugEra": {
+        "drug_era": {
             "Domain_id": "Drug",
             "type": "drug_era"
         },
-        "DrugExposure": {
+        "drug_exposure": {
             "Domain_id": "Drug",
             "type": "drug_exposure"
         },
-        "Measurement": {
+        "measurement": {
             "Domain_id": "Measurement",
             "type": "measurement"
         },
-        "Observation": {
+        "observation": {
             "Domain_id": "Observation",
             "type": "observation"
         },
-        "ObservationPeriod": {
+        "observation_period": {
             "Domain_id": "Observation",
             "type": "observation_period"
         },
-        "ProcedureOccurrence": {
+        "procedure_occurrence": {
             "Domain_id": "Procedure",
             "type": "procedure_occurrence"
         },
-        "Specimen": {
+        "specimen": {
             "Domain_id": "Specimen",
             "type": "specimen"
         },
-        "VisitOccurrence": {
+        "visit_occurrence": {
             "Domain_id": "Visit",
             "type": "visit_occurrence"
         },
-        "VisitDetail": {
+        "visit_detail": {
             "Domain_id": "Visit",
             "type": "visit_detail"
         },
-        "LocationRegion": {
+        "location_region": {
             "Domain_id": "Geography",
             "type": "location_region"
         },
-        "DemographicCriteria": {
+        "demographic": {
             "Domain_id": "Demographic",
             "type": "demographic"
         }

--- a/ai/get_omop_concept_id.py
+++ b/ai/get_omop_concept_id.py
@@ -12,7 +12,7 @@ clickhouse_database = os.environ.get('CLICKHOUSE_DATABASE')
 clickhouse_user = os.environ.get('CLICKHOUSE_USER')
 clickhouse_password = os.environ.get('CLICKHOUSE_PASSWORD')
 openai_api_key = os.environ.get('OPENAI_API_KEY')
-openai_api_base = "https://api.lambdalabs.com/v1"
+openai_api_base = os.environ.get('OPENAI_API_BASE')
 model_name = os.environ.get('LLM_MODEL')
 
 # ClickHouse 클라이언트 초기화

--- a/ai/get_omop_concept_id.py
+++ b/ai/get_omop_concept_id.py
@@ -11,8 +11,8 @@ clickhouse_host = os.environ.get('CLICKHOUSE_HOST')
 clickhouse_database = os.environ.get('CLICKHOUSE_DATABASE')
 clickhouse_user = os.environ.get('CLICKHOUSE_USER')
 clickhouse_password = os.environ.get('CLICKHOUSE_PASSWORD')
-openai_api_key = os.environ.get('OPENAI_API_KEY')
-openai_api_base = os.environ.get('OPENAI_API_BASE')
+openai_api_key = os.environ.get('OPENROUTER_API_KEY')
+openai_api_base = os.environ.get('OPENROUTER_API_BASE')
 model_name = os.environ.get('LLM_MODEL')
 
 # ClickHouse 클라이언트 초기화

--- a/ai/get_omop_concept_id.py
+++ b/ai/get_omop_concept_id.py
@@ -87,24 +87,7 @@ def refine_search_query(term) -> str:
 # ClickHouse에서 concept 정보 조회 (검색 결과가 없으면 용어 수정하여 재시도)
 # # 결과가 너무 많으면 limit만큼만 반환 -> 나중에 늘릴 예정
 def get_omop_concept_id(term: str, domain_id: str, limit: int = 3, auto_refine: bool = True) -> list:
-    """
-    주어진 용어와 도메인에 맞는 concept 정보를 조회합니다.
-    
-    Args:
-        term: 검색할 의학 용어
-        domain_id: 도메인 ID (예: 'Condition', 'Drug', 'Measurement' 등)
-        limit: 반환할 최대 결과 수
-        auto_refine: 검색 결과가 없을 경우 자동으로 용어를 수정하여 재검색할지 여부
-        
-    Returns:
-        concept 정보 목록
-    """
     cleaned_term = clean_term(term)
-    
-    print(f"\n[디버깅] 검색 파라미터:")
-    print(f"- 원본 용어: {term}")
-    print(f"- 정제된 용어: {cleaned_term}")
-    print(f"- 도메인 ID: {domain_id}")
     
     query = """
     WITH limited_concepts AS
@@ -164,19 +147,7 @@ def get_omop_concept_id(term: str, domain_id: str, limit: int = 3, auto_refine: 
     ORDER BY child_count DESC
     """
     
-    print(f"\n[디버깅] 실행할 쿼리:")
-    print(query)
-    print(f"\n[디버깅] 쿼리 파라미터:")
-    print(f"- term: %{cleaned_term}%")
-    print(f"- domain_id: {domain_id}")
-    
     results = clickhouse_client.execute(query, {'term': f'%{cleaned_term}%', 'domain_id': domain_id})
-    
-    print(f"\n[디버깅] 쿼리 결과:")
-    print(f"- 결과 수: {len(results)}")
-    if results:
-        print("- 첫 번째 결과:")
-        print(results[0])
     
     # 결과가 없고 auto_refine이 True이면 용어를 수정하여 재검색
     if not results and auto_refine:
@@ -215,24 +186,24 @@ def get_omop_concept_id(term: str, domain_id: str, limit: int = 3, auto_refine: 
 
 # concept_set_id에 해당하는 filter의 type을 찾아 domain_id를 반환
 def get_concept_set_domain_id(cohort_json: dict, concept_set_id: str) -> str:
-    print(f"\n[디버깅] concept_set_id '{concept_set_id}'에 대한 도메인 ID 검색:")
+    # print(f"\n[디버깅] concept_set_id '{concept_set_id}'에 대한 도메인 ID 검색:")
     
     for group in cohort_json.get("cohort", []):
         for container in group.get("containers", []):
             for filter_obj in container.get("filters", []):
                 if filter_obj.get("conceptset") == concept_set_id:
                     criteria_type = filter_obj["type"]
-                    print(f"- 찾은 criteria_type: {criteria_type}")
+                    # print(f"- 찾은 criteria_type: {criteria_type}")
                     
                     criteria_info = cohort_json_schema.map_criteria_info(criteria_type)
                     if criteria_info:
                         domain_id = criteria_info["Domain_id"]
-                        print(f"- 매핑된 domain_id: {domain_id}")
+                        # print(f"- 매핑된 domain_id: {domain_id}")
                         return domain_id
-                    else:
-                        print(f"- criteria_type '{criteria_type}'에 대한 매핑 정보가 없습니다.")
+                    # else:
+                    #     print(f"- criteria_type '{criteria_type}'에 대한 매핑 정보가 없습니다.")
     
-    print(f"- concept_set_id '{concept_set_id}'에 대한 도메인 ID를 찾을 수 없습니다.")
+    # print(f"- concept_set_id '{concept_set_id}'에 대한 도메인 ID를 찾을 수 없습니다.")
     return None
 
 # concept_set의 items를 DB에서 조회한 결과로 업데이트

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -241,19 +241,8 @@ def extract_terms_from_text(text: str) -> dict:
         print(f"Traceback: {traceback.format_exc()}")
         return {"conceptsets": [], "cohort": []}
 
-def main():
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    
-    # PDF 파일 경로
-    # pdf_path = os.path.join(current_dir, "pdf", "A novel clinical prediction model for in-hospital mortality in sepsis patients complicated by ARDS- A MIMIC IV database and external validation study.pdf")
-    pdf_path = os.path.join(current_dir, "pdf", "NEJMoa2211868.pdf")
-    
-    # 1. PDF에서 텍스트 추출
-    implementable_text, non_implementable_text = extract_cohort_definition_from_pdf(pdf_path)
-    
-    print("\n[Implementable Criteria 부분만]:")
-    print(implementable_text)
-    
+# 텍스트에서 코호트 정의를 추출하여 JSON 형식으로 변환
+def text_to_json(implementable_text: str) -> dict:
     # 2. 텍스트에서 criteria 추출 (implementable 부분만 사용)
     cohort_json = extract_terms_from_text(implementable_text)
     print("\n[cohort_json]:")
@@ -269,11 +258,32 @@ def main():
     print("\n[cohort_json with concept_ids]:")
     print(json.dumps(cohort_json, indent=2, ensure_ascii=False))
     
+    return cohort_json
+
+
+def main():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    
+    # PDF 파일 경로
+    # pdf_path = os.path.join(current_dir, "pdf", "A novel clinical prediction model for in-hospital mortality in sepsis patients complicated by ARDS- A MIMIC IV database and external validation study.pdf")
+    # pdf_path = os.path.join(current_dir, "pdf", "NEJMoa2211868.pdf")
+    pdf_path = os.path.join(current_dir, "pdf", "jama_dulhunty_2024_oi_240070_1723741887.30473.pdf")
+    
+    # 1. PDF에서 텍스트 추출
+    implementable_text, non_implementable_text = extract_cohort_definition_from_pdf(pdf_path)
+    
+    print("\n[Implementable Criteria 부분만]:")
+    print(implementable_text)
+    
+    # 2. 텍스트에서 COHORT JSON 추출
+    cohort_json = text_to_json(implementable_text)
+
     # 4. JSON 파일로 저장
     output_file = os.path.join(current_dir, "cohort_criteria_sample.json")
     with open(output_file, "w", encoding="utf-8") as f:
         json.dump(cohort_json, f, indent=4, ensure_ascii=False)
     print(f"\nCohort definition saved to: {output_file}")
+
 
 if __name__ == "__main__":
     main()

--- a/ai/pdf_to_cohort.py
+++ b/ai/pdf_to_cohort.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 
 load_dotenv()
 openai_api_key = os.environ.get('OPENAI_API_KEY')
-openai_api_base = "https://api.lambdalabs.com/v1"
+openai_api_base = os.environ.get('OPENAI_API_BASE')
 model_name = os.environ.get('LLM_MODEL')
 
 client = OpenAI(

--- a/ai/pdf_to_text.py
+++ b/ai/pdf_to_text.py
@@ -5,7 +5,7 @@ import os
 
 load_dotenv()
 openai_api_key = os.environ.get('OPENAI_API_KEY')
-openai_api_base = "https://api.lambdalabs.com/v1"
+openai_api_base = os.environ.get('OPENAI_API_BASE')
 model_name = os.environ.get('LLM_MODEL')
 client = OpenAI(
     api_key=openai_api_key,

--- a/ai/pdf_to_text.py
+++ b/ai/pdf_to_text.py
@@ -4,8 +4,8 @@ from dotenv import load_dotenv
 import os
 
 load_dotenv()
-openai_api_key = os.environ.get('OPENAI_API_KEY')
-openai_api_base = os.environ.get('OPENAI_API_BASE')
+openai_api_key = os.environ.get('OPENROUTER_API_KEY')
+openai_api_base = os.environ.get('OPENROUTER_API_BASE')
 model_name = os.environ.get('LLM_MODEL')
 client = OpenAI(
     api_key=openai_api_key,
@@ -33,14 +33,14 @@ def extract_cohort_definition_from_pdf(pdf_path):
     
     # 코호트 추출을 위한 프롬프트
     cohort_prompt = f"""
-    You are an expert in extracting cohort definitions (inclusion and exclusion criteria) from clinical documents and mapping them to OMOP CDM compatible format.
+    You are an expert in extracting cohort definitions from clinical documents.
     Please identify and organize the patient inclusion criteria and exclusion criteria from the given text.
 
-    IMPORTANT: Cohort criteria (inclusion and exclusion) are typically grouped together in specific sections or paragraphs. Look for sections labeled with terms like "Eligibility Criteria", "Selection Criteria", "Inclusion/Exclusion Criteria", etc. Focus on these complete sections rather than trying to piece together criteria from separate parts of the document.
+    IMPORTANT: Look for sections labeled with terms like "Eligibility Criteria", "Selection Criteria", "Inclusion/Exclusion Criteria", etc.
 
-    CRITICAL: Each criterion must be listed separately on its own line. If a single line contains multiple conditions (e.g., "Patients diagnosed with sepsis-3 and ARDS"), split it into separate criteria (e.g., "Patients diagnosed with sepsis-3" and "Patients diagnosed with ARDS"). Never combine multiple medical conditions in a single criterion.
+    CRITICAL: Each criterion must be listed separately on its own line. If a single line contains multiple conditions, split it into separate criteria.
 
-    Based on the OMOP CDM schema, you should categorize the criteria into two groups:
+    Based on the OMOP CDM schema, categorize the criteria into two groups:
     1. Criteria that can be implemented in OMOP CDM
     2. Criteria that cannot be directly implemented in OMOP CDM
 
@@ -58,7 +58,7 @@ def extract_cohort_definition_from_pdf(pdf_path):
 
     The following types of criteria CANNOT be directly implemented in OMOP CDM:
     - Subjective assessments without clear definitions
-    - Criteria based on unstructured data (e.g., physician notes interpretation)
+    - Criteria based on unstructured data
     - Free text descriptions that cannot be mapped to standard concepts
     - Patient-reported outcomes not captured in structured data
     - Complex temporal relationships that cannot be expressed in the CDM
@@ -66,9 +66,8 @@ def extract_cohort_definition_from_pdf(pdf_path):
     When handling medical terminology:
     1. Preserve the original medical terms as written in the document.
     2. [CRITICAL] If abbreviations are used, you MUST expand them to their full medical terms.
-       This is the MOST IMPORTANT rule - always expand all medical abbreviations.
        Examples:
-       * "ESA" → "Erythropoiesis Stimulating Agent "
+       * "ESA" → "Erythropoiesis Stimulating Agent"
        * "CKD" → "Chronic Kidney Disease"
        * "HTN" → "Hypertension"
        * "DM" → "Diabetes Mellitus"
@@ -79,10 +78,9 @@ def extract_cohort_definition_from_pdf(pdf_path):
        * "T2DM" → "Type 2 Diabetes Mellitus"
        * "COPD" → "Chronic Obstructive Pulmonary Disease"
        * "AKI" → "Acute Kidney Injury"
-    3. Keep specific measurements and thresholds exactly as stated (e.g., "Hemoglobin value more than 13 g/dL").
+    3. Keep specific measurements and thresholds exactly as stated.
     4. Maintain the original context of each criterion.
-    5. For vague or overly specific medical terms, consider using standard medical terminology while preserving the original meaning.
-       Example: "Sodium bicarbonate therapy" → "Sodium bicarbonate"
+    5. For vague or overly specific medical terms, use standard medical terminology while preserving the original meaning.
 
     Your response MUST follow this format:
 
@@ -110,31 +108,9 @@ def extract_cohort_definition_from_pdf(pdf_path):
 
     If there are no criteria in any section, write "None identified." in that section.
 
-    Here's an example of what your output might look like:
-
-    Implementable Criteria
-    Inclusion Criteria
-    1. Patients who are 20 years old or older.
-    2. Patients with hemodialysis (HD).
-    3. Patients using Erythropoiesis Stimulating Agent therapy for at least three months.
-    4. Patients with iron deficiency anemia.
-
-    Exclusion Criteria
-    1. Patients in intensive care unit.
-    2. Patients with hemoglobin value more than 13 g/dL.
-    3. Kidney transplant patients.
-    
-    Non-implementable Criteria
-    Inclusion Criteria
-    1. First intensive care unit admission.
-    
-    Exclusion Criteria
-    1. Patients with sepsis or active infections. (Requires specific definition of "active infections")
-    2. An ICU stay duration of less than 24 hours.
-
     Here is the text to analyze:
     {formatted_input}
-    """
+"""
     
     response = client.chat.completions.create(
         model=model_name,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #90 

## 📝 작업 내용

> demographic는 규격상 두번째 그룹부터 올 수 있기 때문에 순서 조정하였음.

> 텍스트에서 구조화된 기준 추출 부분을 없애고 바로 JSON으로 만들도록 통합함.

> 코호트 기준 추출된 텍스트 부터 concept_id 매핑까지 end-to-end 처리 가능하도록 함수 정리함.
> - extract_text_from_pdf() → text → create_cohort_json() 파이프라인 구현
> - pdf 업로드부터 사용 하려면 위와 같은 순서로 실행하면 되고, 사용자가 직접 코호트 기준을 입력하는 경우 create_cohort_json()만 실행하면 됨.


### 스크린샷 (선택)


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
