### PR TITLE
Feat: 커스텀 통계 페이지 레이아웃 구현

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -232,7 +232,7 @@
 										<a href="/custom-chart/new" 
 											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
 											onmouseenter={() => activeMenu = 'custom'}>
-											New Chart
+											Chart Definition
 										</a>
 									</li>
 								</ul>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -107,6 +107,20 @@
 									Person
 								</a>
 							</div>
+
+							<!-- Custom 메뉴 -->
+							<div class="w-[200px]">
+								<a 
+									href="/custom-chart"
+									role="menuitem"
+									tabindex="-1"
+									onmouseenter={() => activeMenu = 'custom'}
+									class="flex items-center h-[60px] w-full px-6 text-[15px] transition-all duration-200
+										{activeMenu === 'custom' ? 'text-slate-900 font-semibold' : 'text-slate-700 font-medium'} 
+										hover:text-slate-900 hover:font-semibold">
+									Custom Chart
+								</a>
+							</div>
 						</div>
 					</div>
 					<div class="flex w-full justify-end">
@@ -199,6 +213,26 @@
 											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
 											onmouseenter={() => activeMenu = 'person'}>
 											Person Search
+										</a>
+									</li>
+								</ul>
+							</div>
+
+							<!-- Custom Chart 섹션 -->
+							<div class="w-[200px] py-4 border-r border-slate-300">
+								<ul class="space-y-3">
+									<li>
+										<a href="/custom-chart" 
+											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
+											onmouseenter={() => activeMenu = 'person'}>
+											Chart List
+										</a>
+									</li>
+									<li>
+										<a href="/custom-chart/new" 
+											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
+											onmouseenter={() => activeMenu = 'custom'}>
+											New Chart
 										</a>
 									</li>
 								</ul>

--- a/frontend/src/routes/custom-chart/+page.svelte
+++ b/frontend/src/routes/custom-chart/+page.svelte
@@ -1,0 +1,214 @@
+<script>
+  import { onMount } from "svelte";
+  import { goto } from "$app/navigation";
+  import Footer from '$lib/components/Footer.svelte';
+
+  let searchQuery = "";
+  let searchInput = "";
+  let errorMessage = "";
+
+  // 페이지네이션 관련 변수
+  let currentPage = 1;
+  const itemsPerPage = 10;
+  let totalPages = 0;
+
+  let data = [
+    {
+      id: "",
+      name: "",
+      description: "",
+      author: "",
+      createdAt: "",
+    },
+  ];
+
+  let filteredData = [...data];
+  let selectedItems = {};
+
+  // 현재 페이지의 데이터만 반환하는 함수
+  $: paginatedData = filteredData.slice(
+    (currentPage - 1) * itemsPerPage,
+    currentPage * itemsPerPage
+  );
+
+  // 전체 페이지 수 계산
+  $: totalPages = Math.ceil(filteredData.length / itemsPerPage);
+
+  // 페이지 번호 배열 생성
+  $: pageNumbers = Array.from({ length: totalPages }, (_, i) => i + 1);
+
+  function changePage(page) {
+    if (page >= 1 && page <= totalPages) {
+      currentPage = page;
+    }
+  }
+
+  async function loadData() {
+    try {
+      const response = await fetch('/custom-chart-list-testdata.json'); // JSON 파일 경로
+      if (!response.ok) {
+        throw new Error("Failed to fetch data");
+      }
+      data = await response.json(); // 데이터를 배열로 변환
+      filteredData = [...data]; // 초기 데이터 설정
+    } catch (error) {
+      console.error("Error loading data:", error);
+    }
+  }
+
+  function filterData() {
+    if (!data.length) return;
+
+    filteredData = data.filter(
+      (item) =>
+        item.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        item.description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        item.author.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+    currentPage = 1; // 검색 시 첫 페이지로 이동
+  }
+
+  function handleSearch() {
+    searchQuery = searchInput;
+    filterData();
+  }
+
+  $: {
+    if (!searchInput) {
+      searchQuery = "";
+      filteredData = [...data];
+    }
+  }
+
+  onMount(() => {
+    loadData();
+  });
+</script>
+
+<div class="min-h-screen bg-gradient-to-b from-blue-50 to-white">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+    <div class="mb-8">
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Custom Chart List</h1>
+      <p class="text-gray-600">Manage your custom charts or create new ones.</p>
+    </div>
+
+    <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+      <div class="flex gap-3 mb-6 items-center">
+        <div class="flex-1">
+          <div class="relative">
+            <input
+              type="text"
+              bind:value={searchInput}
+              placeholder="Search charts by name, description, or author"
+              class="w-full pl-10 pr-24 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            />
+            <span class="absolute left-3 top-2 text-gray-400">🔍</span>
+            <button
+              class="absolute right-0 top-0 h-full px-4 text-sm font-medium text-blue-600 hover:text-blue-800 transition-colors border-l border-gray-300"
+              on:click={handleSearch}
+            >
+              Search
+            </button>
+          </div>
+        </div>
+
+        <a 
+          href="/custom-chart/new"
+          class="px-3 py-2 text-sm font-medium text-blue-600 bg-white border border-blue-600 rounded-md hover:bg-blue-50 transition-colors"
+        >
+          New Chart
+        </a>
+      </div>
+      
+      <div class="overflow-x-auto">
+        <table class="min-w-full">
+          <thead>
+            <tr class="bg-gray-50 text-left">
+              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
+              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+            </tr>
+          </thead>
+          <tbody class="bg-white divide-y divide-gray-200">
+            {#each paginatedData as item (item.id)}
+              <tr class="hover:bg-gray-50 transition-colors cursor-pointer group">
+                <td class="py-3 px-4 text-sm text-gray-500">{item.id}</td>
+                <td class="py-3 px-4">
+                  <a 
+                    href={`/custom-chart/${item.id}`} 
+                    class="text-sm font-medium text-blue-600 hover:text-blue-800 hover:underline"
+                  >
+                    {item.name}
+                  </a>
+                </td>
+                <td class="py-3 px-4 text-sm text-gray-900">{item.description}</td>
+                <td class="py-3 px-4 text-sm text-gray-500">{item.author}</td>
+                <td class="py-3 px-4 text-sm text-gray-500">{item.createdAt}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+
+      <!-- 페이지네이션 UI -->
+      {#if totalPages > 1}
+        <div class="flex items-center justify-center space-x-2 mt-6">
+          <button
+            class="p-2 text-sm font-medium rounded-md transition-colors"
+            class:text-gray-400={currentPage === 1}
+            class:text-blue-600={currentPage !== 1}
+            class:hover:text-blue-800={currentPage !== 1}
+            disabled={currentPage === 1}
+            on:click={() => changePage(currentPage - 1)}
+            aria-label="Previous page"
+          >
+            ‹
+          </button>
+
+          {#each pageNumbers as page}
+            <button
+              class="px-3 py-1 text-sm font-medium rounded-md transition-colors"
+              class:bg-blue-600={currentPage === page}
+              class:text-white={currentPage === page}
+              class:text-gray-600={currentPage !== page}
+              class:hover:bg-blue-100={currentPage !== page}
+              on:click={() => changePage(page)}
+            >
+              {page}
+            </button>
+          {/each}
+
+          <button
+            class="p-2 text-sm font-medium rounded-md transition-colors"
+            class:text-gray-400={currentPage === totalPages}
+            class:text-blue-600={currentPage !== totalPages}
+            class:hover:text-blue-800={currentPage !== totalPages}
+            disabled={currentPage === totalPages}
+            on:click={() => changePage(currentPage + 1)}
+            aria-label="Next page"
+          >
+            ›
+          </button>
+        </div>
+      {/if}
+    </div>
+  </div>
+
+  <!-- Error Message -->
+  {#if errorMessage}
+    <div class="fixed bottom-8 left-1/2 transform -translate-x-1/2 z-50">
+      <div class="bg-red-50 border border-red-200 rounded-md shadow-lg px-6 py-3 text-sm text-red-600 flex items-center">
+        <span>{errorMessage}</span>
+        <button 
+          class="ml-4 text-red-400 hover:text-red-600"
+          on:click={() => errorMessage = ""}
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  {/if}
+  <Footer />
+</div>

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -1,0 +1,110 @@
+<script>
+    import { goto } from "$app/navigation";
+
+    const analysisData = {
+        id: "200001",
+        name: "Metformin Usage in Diabetes Cohort",
+        description: "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
+        author: {
+            name: "Dr. Kim",
+            department: "Endocrinology"
+        },
+        createdAt: "2024/01/10 10:00",
+        totalPatients: 150,
+        targetType: "cohort",
+        targetID: ["100001", "100002", "100003", "100004", "100005"],
+        targetName: ["Diabetes Group", "Hypertension Group", "Respiratory Disease Group", "Asthma Control Cohort", "COVID-19 Recovered Cohort"],
+        chartType: "barchart"
+    };
+</script>
+
+<div class="pl-10 pr-10 flex flex-col md:flex-row gap-4">
+
+    <div class="w-[20%] border rounded-lg overflow-hidden mb-3 mt-3">
+        <!-- 상단 정보 -->
+        <div class="w-full flex items-center justify-between p-3 bg-gray-50">
+            <div class="flex items-center gap-4">
+                <div class="text-blue-600 font-medium">Chart Target</div>
+                <div class="font-medium">
+                    <span class="text-sm text-gray-400">Type</span>
+                    <span class="text-sm text-gray-600">{analysisData.targetType}</span>
+                </div>
+            </div>
+        </div>
+        
+        <!-- 상세 정보 -->
+        <div class="p-4 border-t overflow-y-auto max-h-[200px]">
+            <div class="flex flex-col gap-2">
+                {#each analysisData.targetID as id, index}
+                    <button 
+                        class="w-full flex items-center justify-between px-3 py-2 bg-white rounded-lg border hover:bg-blue-50 transition-colors group"
+                        onclick={() => goto(`/cohort/${id}`)}
+                    >
+                        <div class="flex-1 min-w-0">
+                            <div class="flex items-center gap-1">
+                                <span class="text-[10px] font-medium text-gray-400 truncate">{id}</span>
+                            </div>
+                            <div class="flex items-center gap-1">
+                                <div class="text-xs font-medium text-blue-600 break-words whitespace-normal">{analysisData.targetName[index]}</div>
+                            </div>
+                        </div>
+                        <div class="flex items-center text-gray-400 group-hover:text-blue-600">
+                            ›
+                        </div>
+                    </button>
+                {/each}
+            </div>
+        </div>
+    </div>
+
+    <div class="w-[80%] border rounded-lg overflow-hidden mb-3 mt-3">
+        <!-- 상단 정보 -->
+        <div class="w-full flex items-center justify-between p-3 bg-gray-50">
+            <div class="flex items-center gap-4">
+                <div class="font-medium">
+                    <span class="text-sm text-gray-400">ID</span>
+                    <span class="text-sm text-black-500">{analysisData.id}</span>
+                </div>
+                <div class="text-blue-600 font-medium">{analysisData.name}</div>
+            </div>
+        </div>
+        
+        <!-- 상세 정보 -->
+        <div class="p-4 border-t">
+            <div class="grid grid-cols-3 gap-4 text-sm">
+                <div>
+                    <p class="text-gray-500">Author</p>
+                    <p class="font-medium">{analysisData.author.name}</p>
+                </div>
+                <div>
+                    <p class="text-gray-500">Created at</p>
+                    <p class="font-medium">{new Date(analysisData.createdAt).toLocaleString()}</p>
+                </div>
+                <div>
+                    <p class="text-gray-500">Chart Type</p>
+                    <p class="font-medium">{analysisData.chartType}</p>
+                </div>
+                <div class="col-span-3">
+                    <p class="text-gray-500">Description</p>
+                    <p class="font-medium">{analysisData.description}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- 차트 및 설명 영역 추가 -->
+<div class="border rounded-lg overflow-hidden mb-8 mt-2 ml-10 mr-10">
+    <div class="p-4">
+        <h3 class="text-lg font-semibold text-gray-800">Custom Chart</h3>
+        <div class="mt-2">
+            <!-- 차트 컴포넌트가 들어갈 자리 -->
+            <div class="h-80 bg-gray-200 flex items-center justify-center">
+                <p class="text-gray-500">Chart will be displayed here.</p>
+            </div>
+        </div>
+    </div>
+    <div class="p-4 border-t">
+        <p class="text-gray-500">Chart Detail Information will be displayed here.</p>
+    </div>
+</div>

--- a/frontend/static/custom-chart-list-testdata.json
+++ b/frontend/static/custom-chart-list-testdata.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "200001",
+    "name": "Metformin Usage in Diabetes Cohort",
+    "description": "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
+    "author": "Dr. Kim",
+    "createdAt": "2024/01/10 10:00"
+  },
+  {
+    "id": "200002",
+    "name": "Metformin Usage in Diabetes Cohort",
+    "description": "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
+    "author": "Dr. Lee",
+    "createdAt": "2024/01/10 10:00"
+  },
+  {
+    "id": "200003",
+    "name": "Metformin Usage in Diabetes Cohort",
+    "description": "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
+    "author": "Dr. Park",
+    "createdAt": "2024/01/10 10:00"
+  },
+  {
+    "id": "200004",
+    "name": "Metformin Usage in Diabetes Cohort",
+    "description": "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
+    "author": "Dr. Choi",
+    "createdAt": "2024/01/10 10:00"
+  },
+  {
+    "id": "200005",
+    "name": "Metformin Usage in Diabetes Cohort",
+    "description": "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
+    "author": "Dr. Yoon",
+    "createdAt": "2024/01/10 10:00"
+  }
+]


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#123 

## 📝 작업 내용
커스텀 통계 기능을 네비게이션 바에 추가하고, 커스텀 통계 목록과 통계 페이지를 구현하였습니다. 통계 페이지는 레이아웃 위주로 작업되어 있으며 다음 task로 차트를 넣을 예정입니다.

### 스크린샷 (선택)
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/3973b850-2a6d-4ab7-b4fe-b9e199bfa527" />
- 상단 네비게이션 바
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/73a673b4-db71-40c3-9457-771d15df0400" />
- 커스텀 통계 목록 페이지

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/bf466507-7c54-4960-b4bc-02a0a369b0a9" />
- 커스텀 통계 페이지