### PR TITLE
Feat: 코호트 페이지 기능 추가 및 수정

### DIFF
--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -1,5 +1,6 @@
 <script>
     import { page } from '$app/stores';
+    import { get } from 'svelte/store';
 	import { goto } from '$app/navigation';
 	import { filter } from 'd3';
 	import { onMount, tick } from 'svelte';
@@ -15,6 +16,7 @@
 	let paginatedData = $state([]);
 	let cohortDiv;
 	let resizeObserver;
+	let currentPersonId = $state(null);
 
 	const rowHeight = 35;
 
@@ -34,7 +36,17 @@
 		);
 	}
 
+	function selectUser(personid) {
+		currentPersonId = personid;
+	}
+
 	onMount(async () => {
+
+		const personIdFromUrl = get(page).params.person;
+		if (personIdFromUrl) {
+			currentPersonId = parseInt(personIdFromUrl);
+		}
+
 		if (data.userData.length !== 0) {
 			currentPage = 1;
 			filteredData = data.userData;
@@ -121,17 +133,21 @@
 
 	<div class="flex-1 overflow-y-auto px-2" bind:this={cohortDiv}>
 		<!-- 환자 목록 -->
-		<div class="flex flex-col rounded-lg border border-zinc-200 bg-white shadow-sm">
+		<div class="flex flex-col rounded-lg border border-zinc-200 bg-white shadow-sm overflow-hidden">
 			{#each paginatedData as user}
-				<a href="/cohort/{cohortID}/{user.personid}" class="group transition-colors duration-200 hover:bg-zinc-50">
-					<div class="flex items-center justify-between px-4 py-2 border-b border-zinc-100 h-[33px]">
+				<a href="/cohort/{cohortID}/{user.personid}"
+					class="group transition-colors duration-200 hover:bg-blue-50
+					{currentPersonId === user.personid ? 'bg-blue-100': ''}"
+					onclick={()=> selectUser(user.personid)}>
+					<div class="flex items-center justify-between px-4 py-2 border-b border-zinc-100 overflow-hidden h-[33px]">
 						<div class="flex items-center w-full">
 							<span class="text-xs text-zinc-400 w-[70px]">ID {user.personid}</span>
 							<span class="text-xs text-zinc-600">{user.gender}</span>
 							<span class="text-xs text-zinc-300 mx-1">•</span>
 							<span class="text-xs text-zinc-600">{user.age}세</span>
 						</div>
-						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-3.5 h-3.5 text-zinc-400 opacity-0 group-hover:opacity-100 transition-opacity">
+						<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"
+							class={`w-3.5 h-3.5 text-zinc-400 opacity-0 group-hover:opacity-100 transition-opacity ${currentPersonId === user.personid ? 'opacity-100': 'opacity-0'}`}>
 							<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
 						</svg>
 					</div>

--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -115,6 +115,43 @@
                     {analysisData.totalPatients}
                 </span>
             </div>
+
+            <div class="flex items-center gap-4">
+                <!-- 코호트 수정 버튼 -->
+                <button class="flex items-center justify-center relative group">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-blue-600 hover:text-blue-800">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232a3 3 0 00-4.464 0L3 12.5V17h4.5l7.768-7.768a3 3 0 000-4.464z" />
+                    </svg>
+                    <span class="absolute left-1/2 top-full mt-2 transform -translate-x-1/2 bg-white text-xs text-gray-700 rounded shadow-md p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        Edit
+                    </span>
+                </button>
+
+                <!-- 코호트 복제 버튼 -->
+                <button class="flex items-center justify-center relative group">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4CAF50" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 hover:text-green-800">
+                        <g fill="none" fill-rule="evenodd">
+                            <path d="m16.5 10.5v-8c0-1.1045695-.8954305-2-2-2h-8c-1.1045695 0-2 .8954305-2 2v8c0 1.1045695.8954305 2 2 2h8c1.1045695 0 2-.8954305 2-2z"/>
+                            <path d="m4.5 4.50345827h-2c-1.1045695 0-2 .8954305-2 2v7.99654173c0 1.1045695.8954305 2 2 2h.00345528l8.00000002-.0138241c1.1032187-.001906 1.9965447-.8967767 1.9965447-1.9999971v-1.9827205"/>
+                            <path d="m10.5 3.5v6"/>
+                            <path d="m10.5 3.5v6" transform="matrix(0 1 -1 0 17 -4)"/>
+                        </g>
+                    </svg>
+                    <span class="absolute left-1/2 top-full mt-2 transform -translate-x-1/2 bg-white text-xs text-gray-700 rounded shadow-md p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        Duplicate
+                    </span>
+                </button>
+
+                <!-- 코호트 삭제 버튼 -->
+                <button class="flex items-center justify-center relative group">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-red-600 hover:text-red-800">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                    <span class="absolute left-1/2 top-full mt-2 transform -translate-x-1/2 bg-white text-xs text-gray-700 rounded shadow-md p-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        Delete
+                    </span>
+                </button>
+            </div>
         </div>
         
         <!-- 상세 정보 -->

--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -18,8 +18,7 @@
     const tabs = [
 		{ key: 'definition', label: 'Definition' },
 		{ key: 'features', label: 'Features' },
-		{ key: 'default', label: 'Default Chart' },
-		{ key: 'customizable', label: 'Customizable Chart' },
+		{ key: 'charts', label: 'Charts' },
 	];
 
     let isTableView = $state({
@@ -224,7 +223,7 @@
     {/if}
 
 
-    {#if activeTab == 'default'}
+    {#if activeTab == 'charts'}
         <div class="w-full">
             <div class="grid grid-cols-6 gap-4">
                 <ChartCard
@@ -459,11 +458,6 @@
         </div>
     {/if}
 
-    {#if activeTab == 'customizable'}
-        <div class="p-6">
-            customizable tab 화면
-        </div>
-    {/if}
 </div>
 
 <Footer />

--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -119,7 +119,7 @@
             <div class="flex items-center gap-4">
                 <!-- 코호트 수정 버튼 -->
                 <button class="flex items-center justify-center relative group">
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5 text-blue-600 hover:text-blue-800">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-7 text-blue-600 hover:text-blue-800">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232a3 3 0 00-4.464 0L3 12.5V17h4.5l7.768-7.768a3 3 0 000-4.464z" />
                     </svg>
                     <span class="absolute left-1/2 top-full mt-2 transform -translate-x-1/2 bg-white text-xs text-gray-700 rounded shadow-md p-1 opacity-0 group-hover:opacity-100 transition-opacity">
@@ -129,7 +129,7 @@
 
                 <!-- 코호트 복제 버튼 -->
                 <button class="flex items-center justify-center relative group">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#4CAF50" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 hover:text-green-800">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 20 20" fill="none" stroke="#4CAF50" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 hover:text-green-800">
                         <g fill="none" fill-rule="evenodd">
                             <path d="m16.5 10.5v-8c0-1.1045695-.8954305-2-2-2h-8c-1.1045695 0-2 .8954305-2 2v8c0 1.1045695.8954305 2 2 2h8c1.1045695 0 2-.8954305 2-2z"/>
                             <path d="m4.5 4.50345827h-2c-1.1045695 0-2 .8954305-2 2v7.99654173c0 1.1045695.8954305 2 2 2h.00345528l8.00000002-.0138241c1.1032187-.001906 1.9965447-.8967767 1.9965447-1.9999971v-1.9827205"/>

--- a/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/[person]/+page.svelte
@@ -1,6 +1,8 @@
 <script>
     import { onMount, onDestroy, tick } from "svelte";
     import { slide } from 'svelte/transition';
+    import { get } from 'svelte/store'
+    import { page } from '$app/stores'
     import CDMInfo from "$lib/components/Table/CDMInfo.svelte";
     import Condition from "$lib/components/Table/Condition.svelte";
     import Drug from "$lib/components/Table/Drug.svelte";
@@ -26,6 +28,7 @@
     let isSelectTableOpen = false;
     let isStatisticsView = false;
     let show = false;
+    let cohortIdFromUrl;
     export let data;
 
     let isTableView = {
@@ -327,7 +330,10 @@
     }
 
     onMount(() => {
-        drawTimeline();
+        cohortIdFromUrl = get(page).params.cohortID;
+        console.log(get(page).params.cohortID);
+
+        drawTimeline(); 
 
         const handleResize = () => {
             // 기존 svg 강제 삭제 후 다시 그리기
@@ -355,7 +361,15 @@
 
 <header class="py-4 bg-white border-b w-full">
     <div class="flex justify-between py-2">
+        
         <div class="flex items-center px-[10px] py-[5px] whitespace-nowrap">
+            <a href="/cohort/{cohortIdFromUrl}" aria-label="go back">
+                <button class="flex items-center pr-[10px]" aria-label="go back">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-7 h-7 text-gray-600">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+                    </svg>
+                </button>
+            </a>
             <span class="text-sm text-gray-400">ID</span>
             <span class="text-sm font-medium text-gray-900 ml-1">{personTable.person_id}</span>
             <span class="text-gray-200 mx-3">|</span>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#108 

## 📝 작업 내용
  - [x]  기본적으로 코호트 기본 페이지가 깔려있고, 환자 눌렀을 때 위에 얹혀지는 느낌 (뒤로 가기 페이지로 다시 코호트 페이지로 넘어가기)
  - [x]  환자 눌렀을 때 지금 보고 있는 환자 화면 목록에서 색상 넣어주기
  - [x]  코호트 기본 페이지 수정/삭제/복제 버튼 추가 (아직 기능은 X)
  - [x]  탭 명 변경 (Default Chart → Charts / Customizable Chart 는 삭제)
 
단일 코호트 페이지에서 환자 클릭 시 목록 색상이 바뀌도록 하였고, 코호트의 edit, duplicate, delete 버튼을 추가하였습니다. 아직 코호트 정의 페이지가 완료되지 않아 기능 연결은 하지 못해 먼저 이대로만 PR을 올렸습니다. 이후 작업 이어서 진행하겠습니다.

### 스크린샷 (선택)
<img width="201" alt="image" src="https://github.com/user-attachments/assets/c2141b61-4a72-4e10-ac95-eff525a29347" />
<img width="1231" alt="image" src="https://github.com/user-attachments/assets/0bff70bc-6d09-4479-8f2a-1a62bd1dd172" />



## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
