### PR TITLE
Feat: Custom Chart Page, GroupedBarChart Component 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,8 @@
 			"name": "bento",
 			"version": "0.0.1",
 			"dependencies": {
-				"d3": "^7.9.0"
+				"d3": "^7.9.0",
+				"svelte-dnd-action": "^0.9.61"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
@@ -50,7 +51,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
@@ -698,7 +698,6 @@
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
 			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -712,7 +711,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -721,7 +719,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -729,14 +726,12 @@
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-			"dev": true
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -1044,7 +1039,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
 			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
-			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8.9.0"
 			}
@@ -1174,8 +1168,7 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-			"dev": true
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -1187,7 +1180,6 @@
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
 			"integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1266,6 +1258,19 @@
 				"node": ">= 8"
 			}
 		},
+		"node_modules/anymatch/node_modules/picomatch": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
 		"node_modules/arg": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -1282,7 +1287,6 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
 			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1328,7 +1332,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
 			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1478,7 +1481,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -2222,8 +2224,7 @@
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
-			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-			"dev": true
+			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="
 		},
 		"node_modules/espree": {
 			"version": "10.3.0",
@@ -2258,7 +2259,6 @@
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.5.tgz",
 			"integrity": "sha512-CjNMjkBWWZeHn+VX+gS8YvFwJ5+NDhg8aWZBSFJPR8qQduDNjbJodA2WcwCm7uQa5Rjqj+nZvVmceg1RbHFB9g==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
@@ -2695,7 +2695,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
 			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.6"
 			}
@@ -2815,8 +2814,7 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
@@ -2861,7 +2859,6 @@
 			"version": "0.30.17",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
 			"integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
@@ -3906,7 +3903,6 @@
 			"version": "5.23.2",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.23.2.tgz",
 			"integrity": "sha512-PHP1o0aYJNMatiZ+0nq1W/Z1W1/l5Z94B9nhMIo7gsuTBbxC454g4O5SQMjQpZBUZi5ANYUrXJOE4gPzcN/VQw==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -3948,6 +3944,15 @@
 			"peerDependencies": {
 				"svelte": "^4.0.0 || ^5.0.0-next.0",
 				"typescript": ">=5.0.0"
+			}
+		},
+		"node_modules/svelte-dnd-action": {
+			"version": "0.9.61",
+			"resolved": "https://registry.npmjs.org/svelte-dnd-action/-/svelte-dnd-action-0.9.61.tgz",
+			"integrity": "sha512-xj0jZNdV44MAMbdGIAuBYEombmK7A7ticemOtdR5ErWw0f3IxcfcnrRjlYEK0rRjsahVsU+VdGUMwjPVyXrSrA==",
+			"license": "MIT",
+			"peerDependencies": {
+				"svelte": ">=3.23.0 || ^5.0.0-next.0"
 			}
 		},
 		"node_modules/svelte-eslint-parser": {
@@ -4525,8 +4530,7 @@
 		"node_modules/zimmerframe": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
-			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-			"dev": true
+			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="
 		}
 	}
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,6 +37,7 @@
 		"vite": "^6.0.0"
 	},
 	"dependencies": {
-		"d3": "^7.9.0"
+		"d3": "^7.9.0",
+		"svelte-dnd-action": "^0.9.61"
 	}
 }

--- a/frontend/src/lib/components/Charts/GroupedBarChart/GroupedBarChart.svelte
+++ b/frontend/src/lib/components/Charts/GroupedBarChart/GroupedBarChart.svelte
@@ -1,0 +1,202 @@
+<script>
+    import * as d3 from 'd3';
+    import { onMount, onDestroy } from 'svelte';
+  
+    export let data = [];
+  
+    let svgContainer;
+    let resizeObserver;
+  
+    onMount(() => {
+      drawChart();
+      
+      // 컨테이너 크기 변경 감지
+      if (typeof ResizeObserver !== 'undefined') {
+        resizeObserver = new ResizeObserver(drawChart);
+        resizeObserver.observe(svgContainer);
+      } else {
+        window.addEventListener('resize', drawChart);
+      }
+    });
+    
+    onDestroy(() => {
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      } else {
+        window.removeEventListener('resize', drawChart);
+      }
+    });
+  
+    function drawChart() {
+      if (!data || data.length === 0 || !svgContainer) return;
+  
+      // 컨테이너 크기에 맞게 조정
+      const containerRect = svgContainer.getBoundingClientRect();
+      
+      // 컨테이너 크기 적용 (10px 여백 제거)
+      const width = containerRect.width - 10;
+      const height = containerRect.height - 10;
+      
+      // 데이터 크기에 따라 동적으로 여백 조정
+      const dataCount = new Set(data.map(d => d.group)).size;
+      const marginLeft = Math.min(Math.max(50, 10 + dataCount * 3), 40); // 데이터 수에 따라 25~40px 사이로 조정
+      const marginBottom = Math.min(30, Math.max(20, dataCount * 2)); // 20~30px 사이로 조정
+      
+      const marginTop = 10;
+      const marginRight = 10;
+      const minGroupGap = 20;  // 최소 그룹 간 여백
+      const groupWidth = 50;   // 그룹당 기본 폭 (코호트 수와 막대폭 기준)
+      const totalRequiredWidth = dataCount * (groupWidth + minGroupGap);
+      const finalWidth = Math.max(width, totalRequiredWidth);
+      const barWidth = 17;
+
+  
+      svgContainer.innerHTML = '';
+  
+      // x축 스케일 - 데이터 수에 따라 padding 동적 조정
+      const fx = d3.scaleBand()
+        .domain(new Set(data.map(d => d.group)))
+        .rangeRound([marginLeft, width - marginRight])
+        .paddingInner(Math.min(0.2, 0.2 + (1 / dataCount))) // 데이터가 많을수록 패딩을 줄임
+        .paddingOuter(0.05);
+  
+      const targets = Array.from(new Set(data.map(d => d.target)));
+  
+      const x = d3.scaleBand()
+        .domain(targets)
+        .rangeRound([0, fx.bandwidth()])
+        .padding(Math.min(5, 5 + (1 / targets.length))); // 데이터가 많을수록 패딩을 줄임
+  
+      // 색상 팔레트
+      const customColors = ["#4595EC", "#FF6B6B", "#FFD166", "#06D6A0", "#9D8DF1"];
+  
+      const color = d3.scaleOrdinal()
+        .domain(targets)
+        .range(customColors)
+        .unknown("#ccc");
+  
+      // y축 스케일
+      const y = d3.scaleLinear()
+        .domain([0, d3.max(data, d => d.value) * 1.05]).nice()
+        .range([height - marginBottom, marginTop]);
+  
+      // SVG 생성 - viewBox를 사용하여 자동 스케일링
+      const svg = d3.create("svg")
+        .attr("width", "100%")
+        .attr("height", "100%")
+        .attr("viewBox", `0 0 ${width} ${height}`)
+        .attr("preserveAspectRatio", "xMidYMid meet")
+        .attr("style", "font: 10px sans-serif;");
+  
+      // 배경 그리드
+      svg.append("g")
+        .attr("class", "grid")
+        .attr("transform", `translate(${marginLeft},0)`)
+        .call(d3.axisLeft(y)
+            .tickSize(-(width - marginRight - marginLeft))
+            .tickFormat(""))
+        .call(g => g.select(".domain").remove())
+        .call(g => g.selectAll(".tick line")
+            .attr("stroke", "#e0e0e0")
+            .attr("stroke-opacity", 0.5)
+            .attr("stroke-dasharray", "2,2"));
+  
+      // 막대 그래프 그리기
+      svg.append("g")
+        .selectAll("g")
+        .data(d3.group(data, d => d.group))
+        .join("g")
+          .attr("transform", ([group]) => `translate(${fx(group)},0)`)
+        .selectAll("rect")
+        .data(([, d]) => d)
+        .join("rect")
+          .attr("x", d => x(d.target) + (x.bandwidth() - barWidth) / 2)
+          .attr("y", d => y(d.value))
+          .attr("width", barWidth)
+          .attr("height", d => y(0) - y(d.value))
+          .attr("fill", d => color(d.target))
+          .attr("rx", 1.5)
+          .attr("ry", 1.5)
+          .attr("stroke", "white")
+          .attr("stroke-width", 0.5);
+  
+      // X축 - 데이터가 많으면 글꼴 크기 줄이고 회전
+      const xAxisG = svg.append("g")
+        .attr("transform", `translate(0,${height - marginBottom})`)
+        .call(d3.axisBottom(fx))
+        .call(g => g.select(".domain").attr("stroke", "#888").attr("stroke-width", 0.8))
+        .call(g => g.selectAll(".tick line").attr("stroke", "#888").attr("stroke-width", 0.8));
+        
+      // 데이터 개수에 따라 텍스트 스타일 조정
+      xAxisG.selectAll("text")
+        .style("font-size", `${Math.max(11, 9 - dataCount * 0.5)}px`) // 데이터가 많을수록 작게
+        .style("font-weight", "500")
+        .attr("dx", "-0.5em")
+        .attr("dy", "0.5em")
+        .attr("fill", "#444");
+  
+      // Y축
+      svg.append("g")
+        .attr("transform", `translate(${marginLeft},0)`)
+        .call(d3.axisLeft(y).ticks(5).tickFormat(d => d3.format(".2s")(d)))
+        .call(g => g.select(".domain").attr("stroke", "#888").attr("stroke-width", 0.8))
+        .call(g => g.selectAll(".tick line").attr("stroke", "#888").attr("stroke-width", 0.8))
+        .selectAll("text")
+        .style("font-size", "10px")
+        .style("font-weight", "400")
+        .attr("fill", "#444");
+      
+      // 범례 스타일
+      const legendItemSize = 10;    // 사각형 크기
+      const legendSpacing = 8;      // 항목 간 가로 간격
+      const legendTextPadding = 5;  // 사각형-텍스트 간격
+
+      // 각 항목 너비 계산
+      const legendItemWidths = targets.map(target => {
+        const textWidth = target.length * 6;
+        return legendItemSize + legendTextPadding + textWidth + legendSpacing;
+      });
+
+      // 전체 범례 블록 너비
+      const totalLegendWidth = legendItemWidths.reduce((a, b) => a + b, 0);
+
+      // 우측 끝에서 시작할 x 좌표 계산
+      const startX = width - marginRight - totalLegendWidth;
+
+      // 범례 그룹
+      const legend = svg.append("g")
+        .attr("transform", `translate(${startX}, ${marginTop})`);  // 우측 상단 끝 기준
+
+      let legendX = 0;
+      targets.forEach((target, i) => {
+        const legendGroup = legend.append("g")
+          .attr("transform", `translate(${legendX}, 0)`);
+
+        // 색상 박스
+        legendGroup.append("rect")
+          .attr("width", legendItemSize)
+          .attr("height", legendItemSize)
+          .attr("fill", color(target))
+          .attr("rx", 2)
+          .attr("ry", 2);
+
+        // 텍스트
+        legendGroup.append("text")
+          .attr("x", legendItemSize + legendTextPadding)
+          .attr("y", legendItemSize / 2)
+          .attr("dy", "0.35em")
+          .text(target)
+          .style("font-size", "10px")
+          .attr("fill", "#444");
+
+        // 다음 항목 위치로 이동
+        legendX += legendItemWidths[i];
+      });
+
+
+      svgContainer.appendChild(svg.node());
+    }
+  </script>
+  
+  <div class="w-full h-full flex items-center justify-center mx-5" bind:this={svgContainer}></div>
+  

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -225,7 +225,7 @@
 										<a href="/custom-chart" 
 											class="block text-sm text-slate-600 hover:text-blue-600 transition-colors px-6"
 											onmouseenter={() => activeMenu = 'person'}>
-											Chart List
+											Chart Set List
 										</a>
 									</li>
 									<li>

--- a/frontend/src/routes/custom-chart/+page.svelte
+++ b/frontend/src/routes/custom-chart/+page.svelte
@@ -90,7 +90,7 @@
 <div class="min-h-screen bg-gradient-to-b from-blue-50 to-white">
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
     <div class="mb-8">
-      <h1 class="text-2xl font-bold text-gray-900 mb-2">Custom Chart List</h1>
+      <h1 class="text-2xl font-bold text-gray-900 mb-2">Custom Chart Set List</h1>
       <p class="text-gray-600">Manage your custom charts or create new ones.</p>
     </div>
 
@@ -118,7 +118,7 @@
           href="/custom-chart/new"
           class="px-3 py-2 text-sm font-medium text-blue-600 bg-white border border-blue-600 rounded-md hover:bg-blue-50 transition-colors"
         >
-          New Chart
+          + New Chart Page
         </a>
       </div>
       
@@ -126,12 +126,11 @@
         <table class="min-w-full">
           <thead>
             <tr class="bg-gray-50 text-left">
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Chart Type</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+                <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
+                <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+                <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
+                <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created At</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -147,7 +146,6 @@
                   </a>
                 </td>
                 <td class="py-3 px-4 text-sm text-gray-900">{item.description}</td>
-                <td class="py-3 px-4 text-sm text-gray-900">{item.chartType}</td>
                 <td class="py-3 px-4 text-sm text-gray-500">{item.author}</td>
                 <td class="py-3 px-4 text-sm text-gray-500">{item.createdAt}</td>
               </tr>

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -1,41 +1,83 @@
 <script>
     import { goto } from "$app/navigation";
+    import { tick } from 'svelte';
+    import { slide } from 'svelte/transition';
+    import GroupedBarChart from '$lib/components/Charts/GroupedBarChart/GroupedBarChart.svelte';
 
-    const analysisData = {
-        id: "200001",
-        name: "Metformin Usage in Diabetes Cohort",
-        description: "Bar chart displaying the number of patients in the diabetes cohort based on Metformin usage.",
-        author: {
+
+    const targetSetData = {
+        id: "10001",
+        name: "Custom Target Set 1",
+        description: "Description for Custom Chart Set",
+        author : {
             name: "Dr. Kim",
-            department: "Endocrinology"
+            department: "Lab 1"
         },
         createdAt: "2024/01/10 10:00",
-        totalPatients: 150,
-        targetType: "cohort",
-        targetID: ["100001", "100002", "100003", "100004", "100005"],
-        targetName: ["Diabetes Group", "Hypertension Group", "Respiratory Disease Group", "Asthma Control Cohort", "COVID-19 Recovered Cohort"],
-        chartType: "barchart"
-    };
+        targetID: ["100001", "100002", "100003"],
+        targetName: ["Cohort 1", "Cohort 2", "Cohort 3"]
+    }
+
+    const customChartData = [
+        {
+            id: "20001",
+            name: "Custom Target 1",
+            description: "Description for Custom Chart 1",
+            author : {
+                name: "Dr. Kim",
+                department: "Lab 2"
+            },
+            createdAt: "2024/01/10 10:00",
+            chartType: "Bar Chart",
+            chartData : [
+                { state: 'California', age: '0-18', population: 5000000 },
+                { state: 'California', age: '19-35', population: 7000000 },
+                { state: 'California', age: '36-60', population: 6000000 },
+                { state: 'Texas', age: '0-18', population: 4000000 },
+                { state: 'Texas', age: '19-35', population: 6500000 },
+                { state: 'Texas', age: '36-60', population: 5500000 },
+            ]
+        },
+        {
+            id: "20002",
+            name: "Custom Target 2",
+            description: "Description for Custom Chart 2",
+            author : {
+                name: "Dr. Kim",
+                department: "Endocrinology"
+            },
+            createdAt: "2024/01/10 10:00",
+            chartType: "Bar Chart",
+            chartData: [
+                { target: 'Diabetes Group', age: '0-18', population: 5000000 },
+                { target: 'Diabetes Group', age: '19-35', population: 7000000 },
+                { target: 'Diabetes Group', age: '36-60', population: 6000000 },
+                { target: 'Hypertension Group', age: '0-18', population: 4000000 },
+                { target: 'Hypertension Group', age: '19-35', population: 6500000 },
+                { target: 'Hypertension Group', age: '36-60', population: 5500000 },
+            ]
+        },
+    ]
+
+    let expandedStates = targetSetData.targetID.map(() => false);
+
+    async function toggleExpand(index) { // 코호트 목록 toggle 펼치거나 접기 위한 함수
+        await tick();
+        expandedStates[index] = !expandedStates[index];
+        expandedStates = [...expandedStates];
+    }
 </script>
 
-<div class="pl-10 pr-10 flex flex-col md:flex-row gap-4">
-
-    <div class="w-[20%] border rounded-lg overflow-hidden mb-3 mt-3">
-        <!-- 상단 정보 -->
-        <div class="w-full flex items-center justify-between p-3 bg-gray-50">
-            <div class="flex items-center gap-4">
-                <div class="text-blue-600 font-medium">Chart Target</div>
-                <div class="font-medium">
-                    <span class="text-sm text-gray-400">Type</span>
-                    <span class="text-sm text-gray-600">{analysisData.targetType}</span>
-                </div>
+<div class="px-10">
+    <div class="w-full h-[200px] border rounded-lg overflow-hidden mb-3 mt-3 flex">
+        <!-- 좌측: Custom Target 영역 -->
+        <div class="w-[20%] border-r flex flex-col">
+            <div class="flex items-center justify-between p-3 bg-gray-50 border-b">
+                <div class="text-blue-600 font-medium">Chart Target Set</div>
             </div>
-        </div>
-        
-        <!-- 상세 정보 -->
-        <div class="p-4 border-t overflow-y-auto max-h-[200px]">
-            <div class="flex flex-col gap-2">
-                {#each analysisData.targetID as id, index}
+            
+            <div class="p-4 overflow-y-auto flex flex-col gap-2">
+                {#each targetSetData.targetID as id, index}
                     <button 
                         class="w-full flex items-center justify-between px-3 py-2 bg-white rounded-lg border hover:bg-blue-50 transition-colors group"
                         onclick={() => goto(`/cohort/${id}`)}
@@ -45,7 +87,7 @@
                                 <span class="text-[10px] font-medium text-gray-400 truncate">{id}</span>
                             </div>
                             <div class="flex items-center gap-1">
-                                <div class="text-xs font-medium text-blue-600 break-words whitespace-normal">{analysisData.targetName[index]}</div>
+                                <div class="text-xs font-medium text-blue-600 break-words whitespace-normal">{targetSetData.targetName[index]}</div>
                             </div>
                         </div>
                         <div class="flex items-center text-gray-400 group-hover:text-blue-600">
@@ -55,56 +97,112 @@
                 {/each}
             </div>
         </div>
-    </div>
 
-    <div class="w-[80%] border rounded-lg overflow-hidden mb-3 mt-3">
-        <!-- 상단 정보 -->
-        <div class="w-full flex items-center justify-between p-3 bg-gray-50">
-            <div class="flex items-center gap-4">
-                <div class="font-medium">
-                    <span class="text-sm text-gray-400">ID</span>
-                    <span class="text-sm text-black-500">{analysisData.id}</span>
+        <!-- 우측: 상세 정보 영역 -->
+        <div class="w-[80%] flex flex-col">
+            <div class="flex items-center justify-between p-3 bg-gray-50 border-b">
+                <div class="flex items-center gap-4">
+                    <div class="font-medium">
+                        <span class="text-sm text-gray-400">ID</span>
+                        <span class="text-sm text-black-500">{targetSetData.id}</span>
+                    </div>
+                    <div class="text-blue-600 font-medium">Custom Target Set 1</div>
                 </div>
-                <div class="text-blue-600 font-medium">{analysisData.name}</div>
             </div>
-        </div>
-        
-        <!-- 상세 정보 -->
-        <div class="p-4 border-t">
-            <div class="grid grid-cols-3 gap-4 text-sm">
-                <div>
-                    <p class="text-gray-500">Author</p>
-                    <p class="font-medium">{analysisData.author.name}</p>
-                </div>
-                <div>
-                    <p class="text-gray-500">Created at</p>
-                    <p class="font-medium">{new Date(analysisData.createdAt).toLocaleString()}</p>
-                </div>
-                <div>
-                    <p class="text-gray-500">Chart Type</p>
-                    <p class="font-medium">{analysisData.chartType}</p>
-                </div>
-                <div class="col-span-3">
-                    <p class="text-gray-500">Description</p>
-                    <p class="font-medium">{analysisData.description}</p>
+            
+            <div class="p-4 overflow-y-auto">
+                <div class="grid grid-cols-3 gap-4 text-sm">
+                    <div>
+                        <p class="text-gray-500">Author</p>
+                        <p class="font-medium">{targetSetData.author.name}</p>
+                    </div>
+                    <div>
+                        <p class="text-gray-500">Created at</p>
+                        <p class="font-medium">{new Date(targetSetData.createdAt).toLocaleString()}</p>
+                    </div>
+                    <div class="col-span-3">
+                        <p class="text-gray-500">Description</p>
+                        <p class="font-medium">{targetSetData.description}</p>
+                    </div>
                 </div>
             </div>
         </div>
     </div>
 </div>
 
-<!-- 차트 및 설명 영역 추가 -->
-<div class="border rounded-lg overflow-hidden mb-8 mt-2 ml-10 mr-10">
-    <div class="p-4">
-        <h3 class="text-lg font-semibold text-gray-800">Custom Chart</h3>
-        <div class="mt-2">
-            <!-- 차트 컴포넌트가 들어갈 자리 -->
-            <div class="h-80 bg-gray-200 flex items-center justify-center">
-                <p class="text-gray-500">Chart will be displayed here.</p>
+<div>
+    <div class="flex items-center justify-between px-10 pt-4">
+        <h3 class="text-lg font-semibold text-gray-800">Custom Charts</h3>
+        <div class="flex items-center space-x-2">
+            <div class="text-[14px] text-gray-500">Add a new chart for this target</div>
+            <button class="bg-blue-600 text-white text-xl w-10 h-10 rounded-full flex items-center justify-center hover:bg-blue-700 transition shadow font-medium">
+                + 
+            </button>
+        </div>   
+    </div>
+</div>
+
+<div class="space-y-2 py-4 px-10">
+    {#each customChartData as chart, index}
+        <div class="border rounded-lg overflow-hidden bg-white">
+          <button 
+            class="w-full flex items-center justify-between p-2 hover:bg-gray-50 transition-colors"
+            onclick={() => toggleExpand(index)}
+          >
+            <div class="flex items-start gap-2 flex-1 min-w-0">
+              <svg 
+                class="w-3 h-3 flex-shrink-0 transform transition-transform {expandedStates[index] ? 'rotate-180' : ''}" 
+                fill="none" 
+                stroke="currentColor" 
+                viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-1">
+                  <span class="text-xs font-medium text-gray-400 truncate">{chart.id}</span>
+                </div>
+                <div class="flex items-center gap-1">
+                    <div class="text-sm font-medium text-blue-600 break-words whitespace-normal">{chart.name}</div>
+                </div>
+              </div>
             </div>
+          </button>
+          
+          {#if expandedStates[index]}
+            <div class="p-2 border-t text-sm" transition:slide>
+                <div class="space-y-1">
+                    <div>
+                        <span class="text-gray-500">Author:</span>
+                        <span class="font-regular">{chart.author.name} ({chart.author.department})</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-500">Created at:</span>
+                        <span class="font-regular">{chart.createdAt}</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-500">Description:</span>
+                        <span class="font-regular">{chart.description}</span>
+                    </div>
+                    <div>
+                        <span class="text-gray-500">Chart Type:</span>
+                        <span class="font-regular">{chart.chartType}</span>
+                    </div>
+                </div>
+                <!-- 차트 및 설명 영역 추가 -->
+                <div class="pt-4">
+                    <h3 class="text-lg font-semibold text-gray-800">Custom Chart</h3>
+                    <div class="mt-2">
+                        <div class="h-80 bg-gray-200 flex items-center justify-center">
+                            <p class="text-gray-500">Chart will be displayed here.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="p-4 border-t">
+                    <p class="text-gray-500">Chart Detail Information will be displayed here.</p>
+                </div>
+            </div>
+          {/if}
         </div>
-    </div>
-    <div class="p-4 border-t">
-        <p class="text-gray-500">Chart Detail Information will be displayed here.</p>
-    </div>
+    {/each}
 </div>

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -4,7 +4,7 @@
     import { slide } from 'svelte/transition';
     import GroupedBarChart from '$lib/components/Charts/GroupedBarChart/GroupedBarChart.svelte';
     import { dndzone } from 'svelte-dnd-action';
-
+    import ChartCard from "$lib/components/ChartCard.svelte";
 
     const targetSetData = {
         id: "10001",
@@ -212,13 +212,15 @@
                     </div>
                 </div>
                 <!-- 차트 및 설명 영역 추가 -->
-                <div class="pt-4">
-                    <h3 class="text-lg font-semibold text-gray-800">Custom Chart</h3>
-                    <div class="mt-2">
-                        <div class="h-80 bg-gray-200 flex items-center justify-center">
-                            <p class="text-gray-500">Chart will be displayed here.</p>
+                <div class="pt-4 px-2">
+                    <ChartCard 
+                        title="Custom Chart"
+                        hasXButton = {false}
+                    >
+                        <div class="w-full h-full flex items-center justify-center">
+                            <GroupedBarChart data={customChartData[index].chartData} />
                         </div>
-                    </div>
+                    </ChartCard>
                 </div>
                 <div class="p-4 border-t">
                     <p class="text-gray-500">Chart Detail Information will be displayed here.</p>

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -223,7 +223,23 @@
             </button>
           
           {#if expandedStates[index]}
-            <div class="p-2 border-t text-sm" transition:slide>
+            <div class="p-2 border-t text-sm relative" transition:slide>
+                <button 
+                    aria-label="custom chart delete button",
+                    class="absolute top-2 right-2 p-1.5 rounded-full hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        if(confirm(`"${chart.name}" 차트를 삭제하시겠습니까?`)) {
+                        customChartData = customChartData.filter((_, i) => i !== index);
+                        }
+                    }}
+                >
+                <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="3 6 5 6 21 6"></polyline>
+                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                </svg>
+                </button>
+
                 <div class="space-y-1">
                     <div>
                         <span class="text-gray-500">Author:</span>

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -31,12 +31,18 @@
             createdAt: "2024/01/10 10:00",
             chartType: "Bar Chart",
             chartData : [
-                { state: 'California', age: '0-18', population: 5000000 },
-                { state: 'California', age: '19-35', population: 7000000 },
-                { state: 'California', age: '36-60', population: 6000000 },
-                { state: 'Texas', age: '0-18', population: 4000000 },
-                { state: 'Texas', age: '19-35', population: 6500000 },
-                { state: 'Texas', age: '36-60', population: 5500000 },
+                { group: 'Group 1', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 1', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 1', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 1', target: 'Cohort 4', value: 6000000 },
+                { group: 'Group 2', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 2', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 2', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 2', target: 'Cohort 4', value: 6000000 },
+                { group: 'Group 3', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 3', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 3', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 3', target: 'Cohort 4', value: 6000000 },
             ]
         },
         {
@@ -50,12 +56,37 @@
             createdAt: "2024/01/10 10:00",
             chartType: "Bar Chart",
             chartData: [
-                { target: 'Diabetes Group', age: '0-18', population: 5000000 },
-                { target: 'Diabetes Group', age: '19-35', population: 7000000 },
-                { target: 'Diabetes Group', age: '36-60', population: 6000000 },
-                { target: 'Hypertension Group', age: '0-18', population: 4000000 },
-                { target: 'Hypertension Group', age: '19-35', population: 6500000 },
-                { target: 'Hypertension Group', age: '36-60', population: 5500000 },
+                { group: 'Group 1', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 1', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 1', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 2', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 2', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 2', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 3', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 3', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 3', target: 'Cohort 3', value: 6000000 },
+            ]
+        },
+        {
+            id: "20003",
+            name: "Custom Target 3",
+            description: "Description for Custom Chart 3",
+            author : {
+                name: "Dr. Kim",
+                department: "Endocrinology"
+            },
+            createdAt: "2024/01/10 10:00",
+            chartType: "Bar Chart",
+            chartData: [
+                { group: 'Group 1', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 1', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 1', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 2', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 2', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 2', target: 'Cohort 3', value: 6000000 },
+                { group: 'Group 3', target: 'Cohort 1', value: 5000000 },
+                { group: 'Group 3', target: 'Cohort 2', value: 7000000 },
+                { group: 'Group 3', target: 'Cohort 3', value: 6000000 },
             ]
         },
     ]

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -3,6 +3,7 @@
     import { tick } from 'svelte';
     import { slide } from 'svelte/transition';
     import GroupedBarChart from '$lib/components/Charts/GroupedBarChart/GroupedBarChart.svelte';
+    import { dndzone } from 'svelte-dnd-action';
 
 
     const targetSetData = {
@@ -18,7 +19,7 @@
         targetName: ["Cohort 1", "Cohort 2", "Cohort 3"]
     }
 
-    const customChartData = [
+    let customChartData = [
         {
             id: "20001",
             name: "Custom Target 1",
@@ -60,6 +61,10 @@
     ]
 
     let expandedStates = targetSetData.targetID.map(() => false);
+
+    function handleDnd({ detail }) {
+        customChartData = detail.items;
+    }
 
     async function toggleExpand(index) { // 코호트 목록 toggle 펼치거나 접기 위한 함수
         await tick();
@@ -142,32 +147,49 @@
     </div>
 </div>
 
-<div class="space-y-2 py-4 px-10">
-    {#each customChartData as chart, index}
+<div use:dndzone={{ items: customChartData,
+                    flipDurationMs: 300,
+                    dropTargetStyle: {
+                        backgroundColor: 'transparent',
+                        border: 'none'
+                    }
+                }}
+                onconsider={handleDnd}
+                onfinalize={handleDnd}
+                class="space-y-2 py-4 px-10"
+                >
+    {#each customChartData as chart, index (chart.id)}
         <div class="border rounded-lg overflow-hidden bg-white">
-          <button 
-            class="w-full flex items-center justify-between p-2 hover:bg-gray-50 transition-colors"
-            onclick={() => toggleExpand(index)}
-          >
-            <div class="flex items-start gap-2 flex-1 min-w-0">
-              <svg 
-                class="w-3 h-3 flex-shrink-0 transform transition-transform {expandedStates[index] ? 'rotate-180' : ''}" 
-                fill="none" 
-                stroke="currentColor" 
-                viewBox="0 0 24 24"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-              </svg>
-              <div class="flex-1 min-w-0">
-                <div class="flex items-center gap-1">
-                  <span class="text-xs font-medium text-gray-400 truncate">{chart.id}</span>
+            <button 
+                class="w-full flex items-center justify-between p-2 hover:bg-gray-50 transition-colors"
+                onclick={() => toggleExpand(index)}
+            >
+                <div class="flex items-start gap-2 min-w-0">
+                    <svg 
+                        class="w-3 h-3 flex-shrink-0 transform transition-transform {expandedStates[index] ? 'rotate-180' : ''}" 
+                        fill="none" 
+                        stroke="currentColor" 
+                        viewBox="0 0 24 24"
+                    >
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                    </svg>
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-1">
+                        <span class="text-xs font-medium text-gray-400 truncate">{chart.id}</span>
+                        </div>
+                        <div class="flex items-center gap-1">
+                            <div class="text-sm font-medium text-blue-600 break-words whitespace-normal">{chart.name}</div>
+                        </div>
+                    </div>
                 </div>
-                <div class="flex items-center gap-1">
-                    <div class="text-sm font-medium text-blue-600 break-words whitespace-normal">{chart.name}</div>
+                <div class="flex items-center gap-2 flex-shrink-0 pr-2">
+                    <svg class="w-5 h-5 cursor-move text-gray-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="3" y1="12" x2="21" y2="12"></line>
+                        <line x1="3" y1="6" x2="21" y2="6"></line>
+                        <line x1="3" y1="18" x2="21" y2="18"></line>
+                    </svg>
                 </div>
-              </div>
-            </div>
-          </button>
+            </button>
           
           {#if expandedStates[index]}
             <div class="p-2 border-t text-sm" transition:slide>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#134, #128

## 📝 작업 내용
Custom Chart Page의 레이아웃을 구성하고, GroupedBarChart 컴포넌트를 구현하여 추가했습니다. 커스텀 통계 목록의 순서 조정도 가능합니다. (커스텀 통계의 목록 순서가 조정되면 변경된 목록으로 저장시켜주는 과정도 API 연결이 필요할 것 같습니다.)
아직 확정되지 않은 규격의 test data로 들어가 있습니다. 


## 이후 예정 작업
- box plot 컴포넌트 추가 후, chartType에 따라 boxPlot 혹은 groupedBarChart를 띄우게끔 조건부 처리할 예정입니다.
- 차트에 대한 설명를 하단에 추가할 예정입니다.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/8ff2fd1f-f529-4b13-a106-73711497a45d)


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).