### PR TITLE
Feat: Feature Extractor 문구 수정

### DIFF
--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -410,7 +410,7 @@
                 <div class="mt-8">
                     <div class="flex justify-between items-center mb-2">
                         {#if featureData.multiple > 0}
-                            <span class="text-sm text-gray-600">Comparison Size Multiplier: {featureData.multiple}x</span>
+                            <span class="text-sm text-gray-600">Comparison Size(people) : {analysisData.totalPatients * featureData.multiple} ({featureData.multiple} x {analysisData.totalPatients})</span>
                         {:else}
                             <span></span>
                         {/if}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#160 
## 📝 작업 내용
`Comparison Size Multiplier: {featureData.multiple}x`라고 뜨던 문구를  `Comparison Size(people) : {analysisData.totalPatients * featureData.multiple} ({featureData.multiple} x {analysisData.totalPatients})`로 수정하였습니다.


### 스크린샷 (선택)
<img width="1180" alt="image" src="https://github.com/user-attachments/assets/90aa7d7a-b355-4f5b-ab84-4b99fdbeaa72" />



## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
