### PR TITLE
Feat: Custom Chart Page 개선

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"d3": "^7.9.0",
+				"dom-to-image": "^2.6.0",
 				"svelte-dnd-action": "^0.9.61"
 			},
 			"devDependencies": {
@@ -1979,6 +1980,12 @@
 			"resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
 			"integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
 			"dev": true
+		},
+		"node_modules/dom-to-image": {
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/dom-to-image/-/dom-to-image-2.6.0.tgz",
+			"integrity": "sha512-Dt0QdaHmLpjURjU7Tnu3AgYSF2LuOmksSGsUcE6ItvJoCWTBEmiMXcqBdNSAm9+QbbwD7JMoVsuuKX6ZVQv1qA==",
+			"license": "MIT"
 		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
 	},
 	"dependencies": {
 		"d3": "^7.9.0",
+		"dom-to-image": "^2.6.0",
 		"svelte-dnd-action": "^0.9.61"
 	}
 }

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -217,6 +217,7 @@
     }
     
     let expandedStates = cohortIds.map(() => false);
+    let chartDefinitionStates = chartData.charts.map(() => false);
 
     function handleDnd({ detail }) {
         chartData.charts = detail.items.map(item => {
@@ -258,6 +259,12 @@
         } catch (error) {
             console.error('Export error:', error);
         }
+    }
+
+    async function toggleChartDefinition(chartIndex) {
+        await tick();
+        chartDefinitionStates[chartIndex] = !chartDefinitionStates[chartIndex];
+        chartDefinitionStates = [...chartDefinitionStates];
     }
 
 </script>
@@ -356,21 +363,23 @@
                 class="w-full flex items-center justify-between p-2 hover:bg-gray-50 transition-colors"
                 onclick={() => toggleExpand(index)}
             >
-                <div class="flex items-start gap-2 min-w-0">
+                <div class="flex items-center gap-2">
                     <svg 
-                        class="w-3 h-3 flex-shrink-0 transform transition-transform {expandedStates[index] ? 'rotate-180' : ''}" 
+                        class="w-3 h-3 mr-3 flex-shrink-0 transform transition-transform {expandedStates[index] ? 'rotate-0' : '-rotate-90'}" 
                         fill="none" 
                         stroke="currentColor" 
                         viewBox="0 0 24 24"
                     >
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
                     </svg>
-                    <div class="flex-1 min-w-0">
-                        <div class="flex items-center gap-1">
-                        <span class="text-xs font-medium text-gray-400 truncate">{chart.chart_id}</span>
-                        </div>
-                        <div class="flex items-center gap-1">
-                            <div class="text-sm font-medium text-blue-600 break-words whitespace-normal">{chart.name}</div>
+                    <div class="flex items-start gap-2 min-w-0">
+                        <div class="flex-1 min-w-0">
+                            <div class="flex items-center gap-1">
+                            <span class="text-xs font-medium text-gray-400 truncate">{chart.chart_id}</span>
+                            </div>
+                            <div class="flex items-center gap-1">
+                                <div class="text-sm font-medium text-blue-600 break-words whitespace-normal">{chart.name}</div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -451,25 +460,45 @@
                     </ChartCard>
                 </div>
                 <div class="p-4 border-t mt-5">
-                    <h4 class="text-md font-medium text-gray-700 mb-3">Chart Definition</h4>
-                    {#each chart.definition.groups as group, index}
-                        <div class="mb-4 last:mb-0">
-                            <div class="flex items-center justify-between mb-2">
-                                <h5 class="text-sm font-medium text-blue-600">{group.name}</h5>
-                                <button 
-                                    class="text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 text-gray-600 rounded transition-colors flex items-center gap-1"
-                                    onclick={() => copyToClipboard(JSON.stringify(group.definition, null, 2))}
-                                >
-                                    <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                        <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                                        <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-                                    </svg>
-                                    Copy
-                                </button>
-                            </div>
-                            <pre class="bg-gray-50 p-3 rounded-lg text-xs text-gray-600 overflow-x-auto whitespace-pre-wrap">{JSON.stringify(group.definition, null, 2)}</pre>
+                    <div class="flex justify-start items-center">
+                        <button 
+                            aria-label="toggle chart definition"
+                            class="flex items-center gap-2 p-1 rounded-full hover:bg-gray-100 transition-colors"
+                            onclick={() => toggleChartDefinition(index)}
+                        >
+                            <svg 
+                                class="w-3 h-3 flex-shrink-0 transform transition-transform {chartDefinitionStates[index] ? 'rotate-0' : '-rotate-90'}" 
+                                fill="none" 
+                                stroke="currentColor" 
+                                viewBox="0 0 24 24"
+                            >
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                            </svg>
+                            <div class="text-md font-medium text-gray-700">Chart Definition</div>
+                        </button>
+                    </div>
+                    {#if chartDefinitionStates[index]}
+                        <div transition:slide>
+                            {#each chart.definition.groups as group, index}
+                                <div class="mb-4 ml-6 last:mb-0">
+                                    <div class="flex items-center justify-between mb-2">
+                                        <h5 class="text-sm font-medium text-blue-600">{group.name}</h5>
+                                        <button 
+                                            class="text-xs px-2 py-1 bg-gray-100 hover:bg-gray-200 text-gray-600 rounded transition-colors flex items-center gap-1"
+                                            onclick={() => copyToClipboard(JSON.stringify(group.definition, null, 2))}
+                                        >
+                                            <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                                                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
+                                            </svg>
+                                            Copy
+                                        </button>
+                                    </div>
+                                    <pre class="bg-gray-50 p-3 rounded-lg text-xs text-gray-600 overflow-x-auto whitespace-pre-wrap">{JSON.stringify(group.definition, null, 2)}</pre>
+                                </div>
+                            {/each}
                         </div>
-                    {/each}
+                    {/if}
                 </div>
             </div>
           {/if}

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -395,6 +395,7 @@
           {#if expandedStates[index]}
             <div class="p-2 border-t text-sm relative" transition:slide>
                 <button 
+                    title="Delete Chart"
                     aria-label="custom chart delete button",
                     class="absolute top-2 right-2 p-1.5 rounded-full hover:bg-red-50 text-gray-400 hover:text-red-500 transition-colors"
                     onclick={(e) => {
@@ -410,6 +411,7 @@
                 </svg>
                 </button>
                 <button 
+                    title="Download Chart Image"
                     aria-label="export chart image"
                     class="absolute top-2 right-10 p-1.5 rounded-full hover:bg-green-50 text-gray-400 hover:text-green-500 transition-colors"
                     onclick={(e) => {

--- a/frontend/src/routes/custom-chart/[chartID]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[chartID]/+page.svelte
@@ -6,6 +6,7 @@
     import { dndzone } from 'svelte-dnd-action';
     import ChartCard from "$lib/components/ChartCard.svelte";
     import BoxPlot from '$lib/components/Charts/BoxPlot/BoxPlot.svelte';
+    import domtoimage from 'dom-to-image';
 
     const targetSetData = {
         statistics_id: "10001",
@@ -240,6 +241,25 @@
             console.error('클립보드 복사 실패:', err);
         }
     }
+
+    async function exportChartImage(chartId, format = 'png') {
+        const chartElement = document.getElementById(`chart-${chartId}`);
+        if (!chartElement) {
+            console.error(`Chart element not found for id: chart-${chartId}`);
+            return;
+        }
+
+        try {
+            const dataUrl = await domtoimage.toPng(chartElement);
+            const link = document.createElement('a');
+            link.download = `${chartId}.${format}`;
+            link.href = dataUrl;
+            link.click();
+        } catch (error) {
+            console.error('Export error:', error);
+        }
+    }
+
 </script>
 
 <div class="px-10">
@@ -380,6 +400,20 @@
                     <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
                 </svg>
                 </button>
+                <button 
+                    aria-label="export chart image"
+                    class="absolute top-2 right-10 p-1.5 rounded-full hover:bg-green-50 text-gray-400 hover:text-green-500 transition-colors"
+                    onclick={(e) => {
+                        e.stopPropagation();
+                        exportChartImage(chart.chart_id, 'png'); // png or 'jpeg'
+                    }}
+                >
+                    <svg class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+                        <polyline points="7 10 12 15 17 10"></polyline>
+                        <line x1="12" y1="15" x2="12" y2="3"></line>
+                    </svg>
+                </button>
 
                 <div class="space-y-1">
                     <div>
@@ -407,7 +441,7 @@
                         hasXButton = {false}
                         height="400px"
                     >
-                        <div class="w-full h-full flex items-center justify-center">
+                        <div id={"chart-"+chart.chart_id} class="w-full h-full flex items-center justify-center">
                             {#if chart.type === "boxplot"}
                                 <BoxPlot data={chart} />
                             {:else}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#172 

## 📝 작업 내용
- [x] 차트 다운로드 기능 추가 (png)
- [x] chart definition 토글 기능 추가

5월 8일 선생님 미팅 때 받은 피드백을 반영하여 Custom Chart Page에 두 가지 기능을 추가하였습니다.

1. `delete` 버튼 옆 `download` 버튼을 추가하였습니다. 해당 버튼 클릭시 chart id 를 파일명으로 한 png 파일이 다운로드됩니다. `dom-to-image` 패키지를 사용하였습니다.
2. Chart Definition이 너무 길어진다는 피드백을 받아 Chart Definition은 토글로 열 수 있게 하였습니다. 현재 차트 별 definition 토글 기능이 추가되었고, 차트 하나 당 그룹 내 토글까지는 추가하지 않았습니다. 마우스 클릭이 많아져 번거로워질 것 같다고 판단하였는데, 다른 의견 있으시면 피드백 부탁드리겠습니다. 

### 스크린샷
<img width="1391" alt="image" src="https://github.com/user-attachments/assets/c5554df1-f5b1-479f-b912-c65b8d141039" />

<img width="1387" alt="image" src="https://github.com/user-attachments/assets/1f587ad5-5610-4ec3-96ed-235e3467efd9" />

아래 이미지는 png로 다운로드 받은 차트 이미지입니다. (뒷 배경이 투명하여 다른 문서나 자료에 쉽게 첨부할 수 있습니다.)
![20002 (1)](https://github.com/user-attachments/assets/3ed91fe4-fb2c-4c89-b5f2-35b7cd8095b8)

![20003](https://github.com/user-attachments/assets/569d869d-a4f8-4ef5-9add-2fda09ea8952)


## ✅ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
