### PR TITLE
Fix: overflow 버그 해결

### DIFF
--- a/frontend/src/lib/components/Charts/BarChart/BarChartWrapper.svelte
+++ b/frontend/src/lib/components/Charts/BarChart/BarChartWrapper.svelte
@@ -56,11 +56,11 @@
         />
     </div>
 
-    {#if tooltipVisible}
+    <!-- {#if tooltipVisible}
       <div bind:this={tooltipElement}
         class="absolute bg-white/95 shadow-sm rounded-md border border-gray-100 z-50 pointer-events-none transition-all duration-75 backdrop-blur-sm"
         style="left: {tooltipX}px; top: {tooltipY}px;">
         {@html tooltipContent}
       </div>
-    {/if}
+    {/if} -->
   </div>

--- a/frontend/src/lib/components/Charts/LineChart/LineChart.svelte
+++ b/frontend/src/lib/components/Charts/LineChart/LineChart.svelte
@@ -219,6 +219,11 @@
                 .attr("x", 20)
                 .attr("y", 9.5)
                 .attr("dy", "0.02em")
+                .text(d => {
+                    const maxLength = 18;
+                    return d[0].length > maxLength ? d[0].slice(0, maxLength - 1) + "…" : d[0];
+                })
+                .append("title") // hover 시 전체 이름 표시
                 .text(d => d[0])
                 .style("opacity", d => visibleSeries.has(d[0]) ? 1 : 0.5)
                 .style("cursor", "pointer")

--- a/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChartWrapper.svelte
+++ b/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChartWrapper.svelte
@@ -69,12 +69,12 @@
     </div>
 
   <!-- 툴팁 -->
-  {#if tooltipVisible}
+  <!-- {#if tooltipVisible}
     <div bind:this={tooltipElement}
     class="absolute bg-white/95 shadow-sm rounded-md border border-gray-100 z-50 pointer-events-none transition-all duration-75 backdrop-blur-sm"
     style="left: {tooltipX}px; top: {tooltipY}px;"
     >
       {@html tooltipContent}
     </div>
-  {/if}
+  {/if} -->
 </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#193 

## 📝 작업 내용

### 통계, 코호트 페이지 관련
- [x]  Top 10 차트에서 이름 너무 길어질 때 좌측 부분 overflow되어서 안보이는 문제
    - [x] 단일 코호트 통계
    - [x] 다중 코호트 통계
- [x]  다중 코호트 통계에서 이름 길어졌을 때 범례 텍스트 우측으로 overflow 되는거


### 스크린샷 (선택)
<img width="1218" alt="image" src="https://github.com/user-attachments/assets/9d1db7b6-8e94-44d7-97ff-3af42d8b265a" />
ㄴ 단일 코호트 통계의 Top 10 
<img width="1175" alt="image" src="https://github.com/user-attachments/assets/3509244c-5f88-48f2-8d50-b4dd95747804" />
ㄴ 다중 코호트 통계의 Top 10 

<img width="1174" alt="image" src="https://github.com/user-attachments/assets/50ae6b68-798a-4833-875d-c86cefb55bfe" />
ㄴ 다중 코호트 통계의 LineChart Legend


## 💬 리뷰 요구사항(선택)
tooltip을 수정하며 기존 tooltip은 우선 주석처리로만 제거해두었습니다. 추후 다시 리팩토링하여 완전히 제거하도록 하겠습니다. 


## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
