### PR TITLE
Feat: 개별 환자에 페이지네이션 추가

### DIFF
--- a/frontend/src/lib/components/Table/Condition.svelte
+++ b/frontend/src/lib/components/Table/Condition.svelte
@@ -65,7 +65,7 @@
     <!-- 페이지네이션 컨트롤 -->
     <div class="flex justify-between items-center mt-4">
       <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
-      <p class="text-sm">Page {currentPage} of {Math.ceil(combinedData.length / itemsPerPage)}</p>
+      <p class="text-sm">Page <input bind:value={currentPage} on:input={(e) => goToPage(e.target.value)} class="border-none w-10 p-0 text-center" /> of {Math.ceil(combinedData.length / itemsPerPage)}</p>
       <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
     </div>
   {:else}

--- a/frontend/src/lib/components/Table/Condition.svelte
+++ b/frontend/src/lib/components/Table/Condition.svelte
@@ -2,14 +2,45 @@
   export let conditionOccurrence;
   export let conditionEra;
 
-  console.log(conditionOccurrence);
+  let currentPage = 1;
+  let itemsPerPage = 10;
+
+  // 두 배열을 합쳐 하나로 통합
+  let combinedData = [];
+  $: combinedData = [...(conditionOccurrence || []).map(cond => ({
+    type: 'Occurrence',
+    concept_name: cond.concept_name,
+    period: `${cond.condition_start_date} ~ ${cond.condition_end_date}`,
+    status: cond.condition_status_source_value ? cond.condition_status_source_value : 'null'
+  })),
+  ...(conditionEra || []).map(era => ({
+    type: 'Era',
+    concept_name: era.concept_name,
+    period: `${era.condition_era_start_date} ~ ${era.condition_era_end_date}`,
+    status: `${era.condition_occurrence_count} times`
+  }))];
+
+  // 페이지네이션 함수
+  function getPaginatedData() {
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return combinedData.slice(start, end);
+  }
+
+  function nextPage() {
+    if (currentPage * itemsPerPage < combinedData.length) currentPage++;
+  }
+
+  function prevPage() {
+    if (currentPage > 1) currentPage--;
+  }
 </script>
 
 <div class="flex flex-col bg-white border border-gray-300 rounded-lg shadow-md p-6 relative mb-1 w-full">
   <h2 class="title">Condition Information</h2>
 
   <!-- Condition Information -->
-  {#if (conditionOccurrence && conditionOccurrence.length > 0) || (conditionEra && conditionEra.length > 0)}
+  {#if combinedData.length > 0}
     <table class="w-full border border-gray-200 text-sm text-left">
       <thead class="bg-gray-100">
         <tr>
@@ -20,33 +51,27 @@
         </tr>
       </thead>
       <tbody>
-        {#if conditionOccurrence}
-          {#each conditionOccurrence as cond}
-            <tr class="hover:bg-gray-50">
-              <td class="px-4 py-2 border-b">Occurrence</td>
-              <td class="px-4 py-2 border-b">{cond.concept_name}</td>
-              <td class="px-4 py-2 border-b">{cond.condition_start_date} ~ {cond.condition_end_date}</td>
-              <td class="px-4 py-2 border-b">{cond.condition_status_source_value ? cond.condition_status_source_value : 'null'}</td>
-            </tr>
-          {/each}
-        {/if}
-        {#if conditionEra}
-          {#each conditionEra as era}
-            <tr class="hover:bg-gray-50">
-              <td class="px-4 py-2 border-b">Era</td>
-              <td class="px-4 py-2 border-b">{era.concept_name}</td>
-              <td class="px-4 py-2 border-b">{era.condition_era_start_date} ~ {era.condition_era_end_date}</td>
-              <td class="px-4 py-2 border-b">{era.condition_occurrence_count} times</td>
-            </tr>
-          {/each}
-        {/if}
+        {#each getPaginatedData() as item}
+          <tr class="hover:bg-gray-50">
+            <td class="px-4 py-2 border-b">{item.type}</td>
+            <td class="px-4 py-2 border-b">{item.concept_name}</td>
+            <td class="px-4 py-2 border-b">{item.period}</td>
+            <td class="px-4 py-2 border-b">{item.status}</td>
+          </tr>
+        {/each}
       </tbody>
     </table>
+
+    <!-- 페이지네이션 컨트롤 -->
+    <div class="flex justify-between items-center mt-4">
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
+      <p class="text-sm">Page {currentPage} of {Math.ceil(combinedData.length / itemsPerPage)}</p>
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
+    </div>
   {:else}
     <p class="text-gray-500 text-sm">No condition data available.</p>
   {/if}
 </div>
-
 
 
 <style>

--- a/frontend/src/lib/components/Table/Drug.svelte
+++ b/frontend/src/lib/components/Table/Drug.svelte
@@ -51,7 +51,7 @@
     <!-- 페이지네이션 컨트롤 -->
     <div class="flex justify-between items-center mt-4">
       <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
-      <p class="text-sm">Page {currentPage} of {Math.ceil(drugExposure.length / itemsPerPage)}</p>
+      <p class="text-sm">Page <input bind:value={currentPage} on:input={(e) => goToPage(e.target.value)} class="border-none w-10 p-0 text-center" /> of {Math.ceil(drugExposure.length / itemsPerPage)}</p>
       <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
     </div>
 

--- a/frontend/src/lib/components/Table/Drug.svelte
+++ b/frontend/src/lib/components/Table/Drug.svelte
@@ -1,26 +1,29 @@
 <script>
   export let drugExposure;
 
-  console.log(drugExposure);
+  let currentPage = 1;
+  let itemsPerPage = 10;
+
+  // 페이지네이션 함수
+  function getPaginatedDrugData() {
+    if (!drugExposure) return [];
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return drugExposure.slice(start, end);
+  }
+
+  function nextPage() {
+    if (currentPage * itemsPerPage < drugExposure.length) currentPage++;
+  }
+
+  function prevPage() {
+    if (currentPage > 1) currentPage--;
+  }
 </script>
 
 <div class="flex flex-col bg-white border border-gray-300 rounded-lg shadow-md p-6 relative mb-1 w-full">
   <h2 class="title">Drug Information</h2>
 
-  <!-- Drug Era (약물 복용 기록) -->
-  <!-- {#each drugEra as era}
-    <div class="drug-row">
-      <span class="info"><strong>Drug Era ID:</strong> {era.drug_era_id}</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Duration:</strong> {era.drug_era_start_date} ~ {era.drug_era_end_date}</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Exposure Count:</strong> {era.drug_exposure_count}회</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Gap Days:</strong> {era.gap_days}일</span>
-    </div>
-  {/each} -->
-
-  <!-- Drug Exposure (약물 투여 기록) -->
   {#if drugExposure && drugExposure.length > 0}
     <table class="drug-table w-full border border-gray-200 text-sm text-left">
       <thead class="bg-gray-100">
@@ -32,32 +35,29 @@
         </tr>
       </thead>
       <tbody>
-        {#each drugExposure as exposure}
+        {#each getPaginatedDrugData() as exposure}
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 border-b">{exposure.concept_name}</td>
             <td class="px-4 py-2 border-b">
               {exposure.drug_exposure_start_date} ~ {exposure.drug_exposure_end_date}
             </td>
             <td class="px-4 py-2 border-b">{exposure.quantity}</td>
-            <td class="px-4 py-2 border-b">{exposure.days_supply ? `${exposure.days_supply} days` : 'null' } </td>
+            <td class="px-4 py-2 border-b">{exposure.days_supply ? `${exposure.days_supply} days` : 'null' }</td>
           </tr>
         {/each}
       </tbody>
     </table>
+
+    <!-- 페이지네이션 컨트롤 -->
+    <div class="flex justify-between items-center mt-4">
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
+      <p class="text-sm">Page {currentPage} of {Math.ceil(drugExposure.length / itemsPerPage)}</p>
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
+    </div>
+
   {:else}
     <p class="text-gray-500 text-sm">No drug exposure data available.</p>
   {/if}
-
-  <!-- Drug Strength (약물 성분 및 용량) -->
-  <!-- {#each drugStrength as strength}
-    <div class="drug-row strength">
-      <span class="info"><strong>Ingredient ID:</strong> {strength.ingredient_concept_id}</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Total Amount:</strong> {strength.amount_value} mg</span>
-      <span class="divider">|</span>
-      <span class="info"><strong>Concentration:</strong> {strength.numerator_value} / {strength.denominator_value}</span>
-    </div>
-  {/each} -->
 </div>
 
 <style>

--- a/frontend/src/lib/components/Table/Measurement.svelte
+++ b/frontend/src/lib/components/Table/Measurement.svelte
@@ -1,5 +1,31 @@
 <script>
   export let measurement;
+
+  let currentPage = 1;
+  let itemsPerPage = 10;
+
+  // 페이지네이션 함수
+  function getPaginatedMeasurementData() {
+    if (!measurement) return [];
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return measurement.slice(start, end);
+  }
+
+  function nextPage() {
+    if (currentPage * itemsPerPage < measurement.length) currentPage++;
+  }
+
+  function prevPage() {
+    if (currentPage > 1) currentPage--;
+  }
+
+  function goToPage(page) {
+    const totalPages = Math.ceil(measurement.length / itemsPerPage);
+    if (page >= 1 && page <= totalPages) {
+      currentPage = page;
+    }
+  }
 </script>
 
 <div class="flex flex-col bg-white border border-gray-300 rounded-lg shadow-md p-6 relative mb-1 w-full">
@@ -15,7 +41,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each measurement as measure}
+        {#each getPaginatedMeasurementData() as measure}
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 border-b">{measure.concept_name}</td>
             <td class="px-4 py-2 border-b">{measure.measurement_date}</td>
@@ -24,6 +50,13 @@
         {/each}
       </tbody>
     </table>
+
+    <!-- 페이지네이션 컨트롤 -->
+    <div class="flex justify-between items-center mt-4">
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
+      <p class="text-sm">Page <input bind:value={currentPage} on:input={(e) => goToPage(e.target.value)} class="border-none w-10 p-0 text-center" /> of {Math.ceil(measurement.length / itemsPerPage)}</p>
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
+    </div>
   {:else}
     <p class="text-gray-500 text-sm mb-6">No measurement data available.</p>
   {/if}
@@ -36,3 +69,4 @@
     margin-bottom: 10px;
   }
 </style>
+ 

--- a/frontend/src/lib/components/Table/Observation.svelte
+++ b/frontend/src/lib/components/Table/Observation.svelte
@@ -1,5 +1,31 @@
 <script>
   export let observation;
+
+  let currentPage = 1;
+  let itemsPerPage = 10;
+
+  // 페이지네이션 함수
+  function getPaginatedObservationData() {
+    if (!observation) return [];
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return observation.slice(start, end);
+  }
+
+  function nextPage() {
+    if (currentPage * itemsPerPage < observation.length) currentPage++;
+  }
+
+  function prevPage() {
+    if (currentPage > 1) currentPage--;
+  }
+
+  function goToPage(page) {
+    const totalPages = Math.ceil(observation.length / itemsPerPage);
+    if (page >= 1 && page <= totalPages) {
+      currentPage = page;
+    }
+  }
 </script>
 
 <div class="flex flex-col bg-white border border-gray-300 rounded-lg shadow-md p-6 relative mb-1 w-full">
@@ -15,7 +41,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each observation as obs}
+        {#each getPaginatedObservationData() as obs}
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 border-b">{obs.concept_name}</td>
             <td class="px-4 py-2 border-b">{obs.observation_date}</td>
@@ -26,6 +52,13 @@
         {/each}
       </tbody>
     </table>
+
+    <!-- 페이지네이션 컨트롤 -->
+    <div class="flex justify-between items-center mt-4">
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
+      <p class="text-sm">Page <input bind:value={currentPage} on:input={(e) => goToPage(e.target.value)} class="border-none w-10 p-0 text-center" /> of {Math.ceil(observation.length / itemsPerPage)}</p>
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
+    </div>
   {:else}
     <p class="text-gray-500 text-sm mb-6">No observation data available.</p>
   {/if}

--- a/frontend/src/lib/components/Table/ProcedureOccurrence.svelte
+++ b/frontend/src/lib/components/Table/ProcedureOccurrence.svelte
@@ -1,5 +1,31 @@
 <script>
   export let procedureOccurrence;
+
+  let currentPage = 1;
+  let itemsPerPage = 10;
+
+  // 페이지네이션 함수
+  function getPaginatedProcedureData() {
+    if (!procedureOccurrence) return [];
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return procedureOccurrence.slice(start, end);
+  }
+
+  function nextPage() {
+    if (currentPage * itemsPerPage < procedureOccurrence.length) currentPage++;
+  }
+
+  function prevPage() {
+    if (currentPage > 1) currentPage--;
+  }
+
+  function goToPage(page) {
+    const totalPages = Math.ceil(procedureOccurrence.length / itemsPerPage);
+    if (page >= 1 && page <= totalPages) {
+      currentPage = page;
+    }
+  }
 </script>
 
 <div class="flex flex-col bg-white border border-gray-300 rounded-lg shadow-md p-6 relative mb-1 w-full">
@@ -16,7 +42,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each procedureOccurrence as proc}
+        {#each getPaginatedProcedureData() as proc}
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 border-b">{proc.concept_name}</td>
             <td class="px-4 py-2 border-b">{proc.procedure_date}</td>
@@ -26,6 +52,13 @@
         {/each}
       </tbody>
     </table>
+
+    <!-- 페이지네이션 컨트롤 -->
+    <div class="flex justify-between items-center mt-4">
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
+      <p class="text-sm">Page <input bind:value={currentPage} on:input={(e) => goToPage(e.target.value)} class="border-none w-10 p-0 text-center" /> of {Math.ceil(procedureOccurrence.length / itemsPerPage)}</p>
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
+    </div>
   {:else}
     <p class="text-gray-500 text-sm mb-6">No procedure data available.</p>
   {/if}

--- a/frontend/src/lib/components/Table/Specimen.svelte
+++ b/frontend/src/lib/components/Table/Specimen.svelte
@@ -1,5 +1,31 @@
 <script>
   export let specimen;
+
+  let currentPage = 1;
+  let itemsPerPage = 10;
+
+  // 페이지네이션 함수
+  function getPaginatedSpecimenData() {
+    if (!specimen) return [];
+    const start = (currentPage - 1) * itemsPerPage;
+    const end = start + itemsPerPage;
+    return specimen.slice(start, end);
+  }
+
+  function nextPage() {
+    if (currentPage * itemsPerPage < specimen.length) currentPage++;
+  }
+
+  function prevPage() {
+    if (currentPage > 1) currentPage--;
+  }
+
+  function goToPage(page) {
+    const totalPages = Math.ceil(specimen.length / itemsPerPage);
+    if (page >= 1 && page <= totalPages) {
+      currentPage = page;
+    }
+  }
 </script>
 
 <div class="flex flex-col bg-white border border-gray-300 rounded-lg shadow-md p-6 relative mb-1 w-full">
@@ -15,7 +41,7 @@
         </tr>
       </thead>
       <tbody>
-        {#each specimen as spec}
+        {#each getPaginatedSpecimenData() as spec}
           <tr class="hover:bg-gray-50">
             <td class="px-4 py-2 border-b">{spec.concept_name}</td>
             <td class="px-4 py-2 border-b">{spec.specimen_date}</td>
@@ -24,6 +50,13 @@
         {/each}
       </tbody>
     </table>
+
+    <!-- 페이지네이션 컨트롤 -->
+    <div class="flex justify-between items-center mt-4">
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={prevPage}>Previous</button>
+      <p class="text-sm">Page <input bind:value={currentPage} on:input={(e) => goToPage(e.target.value)} class="border-none w-10 p-0 text-center" /> of {Math.ceil(specimen.length / itemsPerPage)}</p>
+      <button class="px-3 py-1 bg-gray-200 rounded" on:click={nextPage}>Next</button>
+    </div>
   {:else}
     <p class="text-gray-500 text-sm mb-6">No specimen data available.</p>
   {/if}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#204 

## 📝 작업 내용
개별 환자 테이블에 데이터가 너무 많은 경우 보기 힘들 것으로 예상되어 각 테이블별로 페이지네이션을 구현했습니다.

### 스크린샷 (선택)
<img width="1454" alt="image" src="https://github.com/user-attachments/assets/6cf4975c-00a3-4ab2-b06e-a1ea0bc5a6e6" />

## ✅ PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
