### PR TITLE
Fix: 데이터 없는 경우 처리

### DIFF
--- a/frontend/src/lib/components/Charts/BarChart/BarChart.svelte
+++ b/frontend/src/lib/components/Charts/BarChart/BarChart.svelte
@@ -17,6 +17,8 @@
     $: if (chartContainer && data.length > 0 && width && height) {
         drawChart();
     }
+
+    $: total = data?.reduce((sum, d) => sum + (d?.count || 0), 0) || 0;
     
     function handleResize() {
       if (chartContainer) {
@@ -146,9 +148,17 @@
       }
     });
   
-    $: if (chartContainer && data.length > 0 && width && height) {
+    $: if (chartContainer && data.length > 0 && width && height && total > 0) {
       drawChart();
     }
 </script>
   
-<div bind:this={chartContainer} class="w-full h-full"></div>
+<div class="relative w-full h-full">
+  {#if !data || data.length === 0 || total === 0}
+    <div class="absolute inset-0 flex items-center justify-center">
+      <p class="text-xs text-gray-500 text-center">Currently, no data is available for display.</p>
+    </div>
+  {/if}
+
+  <div bind:this={chartContainer} class="w-full h-full"></div>
+</div>

--- a/frontend/src/lib/components/Charts/DonutChart/DonutChart.svelte
+++ b/frontend/src/lib/components/Charts/DonutChart/DonutChart.svelte
@@ -117,7 +117,11 @@
             </div>
         {/if}
     {:else if processedData.length === 0}
-        <p>Currently, no data is available for display.</p>
+        <div class="flex items-center justify-center h-[150px] w-full">
+            <div class="text-center text-xs text-gray-500">
+            <p>Currently, no data is available for display.</p>
+            </div>
+        </div>
     {/if}
 </div>
 

--- a/frontend/src/lib/components/Charts/DonutChart/DonutChart.svelte
+++ b/frontend/src/lib/components/Charts/DonutChart/DonutChart.svelte
@@ -12,7 +12,8 @@
     let radius = Math.min(width, height) / 2 - margin;
 
     // 데이터가 유효한지 확인하고 처리
-    $: processedData = data && Object.keys(data).length > 0 ? Object.entries(data) : [];
+    $: processedData = typeof data === 'object' && data !== null ? Object.entries(data) : [];
+
     $: color = d3
         .scaleOrdinal()
         .domain([
@@ -90,7 +91,7 @@
 </script>
 
 <div class="chart-container flex flex-col items-center" style="position:relative;">
-    {#if processedData.length > 0}
+    {#if processedData.length > 0 && total > 0}
         <svg {width} {height} viewBox="{-width / 2}, {-height / 2}, {width}, {height}" style:max-width="100%" style:height="auto">
             <g class="chart-inner">
                 {#each data_ready as slice}
@@ -116,7 +117,7 @@
                 <div>{tooltip.value} ({tooltip.percent})</div>
             </div>
         {/if}
-    {:else if processedData.length === 0}
+    {:else}
         <div class="flex items-center justify-center h-[150px] w-full">
             <div class="text-center text-xs text-gray-500">
             <p>Currently, no data is available for display.</p>

--- a/frontend/src/lib/components/Charts/LineChart/LineChart.svelte
+++ b/frontend/src/lib/components/Charts/LineChart/LineChart.svelte
@@ -21,6 +21,8 @@
         visibleSeries = new Set(Object.keys(cohortColorMap));
     }
 
+    $: total = data?.reduce((sum, d) => sum + (d?.value || 0), 0) || 0;
+
     function handleResize() {
         if (chartContainer) {
             const containerRect = chartContainer.getBoundingClientRect();
@@ -72,7 +74,7 @@
     }
 
     function drawChart() {
-        if (!chartContainer || !width || !height || !data || data.length === 0) return;
+        if (!chartContainer || !width || !height || !data || data.length === 0 || total === 0) return;
 
         const svg = d3
             .select(chartContainer)
@@ -250,4 +252,12 @@
     }
 </script>
 
-<div bind:this={chartContainer} class="w-full h-full [&>svg]:max-w-full [&>svg]:h-auto"></div>
+<div class="relative w-full h-full">
+    {#if !data || data.length === 0 || total === 0}
+        <div class="absolute inset-0 flex items-center justify-center">
+        <p class="text-xs text-gray-500 text-center">Currently, no data is available for display.</p>
+        </div>
+    {/if}
+
+    <div bind:this={chartContainer} class="w-full h-full [&>svg]:max-w-full [&>svg]:h-auto"></div>
+</div>  

--- a/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChart.svelte
+++ b/frontend/src/lib/components/Charts/StackedBarChart/StackedBarChart.svelte
@@ -21,6 +21,10 @@
         drawChart();
     }
 
+    $: hasAnyValue = stackData.some(item =>
+        orderedCohorts.some(cohort => +item[cohort] > 0)
+    );
+
     function handleResize() {
         if (chartContainer) {
             const containerRect = chartContainer.getBoundingClientRect();
@@ -32,7 +36,7 @@
 
     // 차트 그리기 함수
     function drawChart() {
-        if (!chartContainer || !width || !height || stackData.length === 0) return;
+        if (!chartContainer || !width || !height || stackData.length === 0 || !hasAnyValue) return;
 
         // 기존 SVG 초기화
         d3.select(chartContainer).selectAll("*").remove();
@@ -166,4 +170,14 @@
     
 </script>
 
-<div bind:this={chartContainer} class="w-full h-full"></div>
+<div class="relative w-full h-full">
+    {#if stackData.length > 0 && !hasAnyValue}
+        <div class="absolute inset-0 flex items-center justify-center">
+        <p class="text-xs text-gray-500 text-center">
+            Currently, no data is available for display.
+        </p>
+        </div>
+    {/if}
+
+    <div bind:this={chartContainer} class="w-full h-full"></div>
+</div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#207 

## 📝 작업 내용
차트 데이터가 없거나 모두 0이라서 렌더링할 수 없을 경우 `Currently, no data is available for display.`라는 문구를 표시해주었습니다.


### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/39467fa4-fb26-4730-b03e-b825253d54b1)
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/f01e6cd2-f677-40fe-b3b7-8cc87edf003e" />

## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
