### PR TITLE
Fix Person Search 페이지의 타임라인 뷰의 툴팁 배치 오류 해결

### DIFF
--- a/frontend/src/routes/person/[personID]/+page.svelte
+++ b/frontend/src/routes/person/[personID]/+page.svelte
@@ -509,7 +509,7 @@
     </div>
     <!-- 🔹 타임라인을 렌더링할 컨테이너 -->
     <div class="flex gap-4">
-        <div class="w-4/5 h-[220px] min-w-[850px]" bind:this={timelineContainer}></div>
+        <div class="w-4/5 h-[220px] min-w-[850px] relative" bind:this={timelineContainer}></div>
         <div class="w-1/5 border rounded-lg p-4 bg-white shadow-md h-[220px] overflow-y-auto">
             <h2 class="text-lg font-bold mb-2">Overlapping Visits</h2>
             {#if selectedGroup}


### PR DESCRIPTION

## 📝 작업 내용

> Person Search 페이지의 타임라인 뷰의 툴팁 배치 오류 해결 relative 클래스를 추가 안하여 툴팁이 absolute에 의해서 페이지의 상단에 표시되는 버그를 해결함

## ✅ PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
