### PR TITLE
Fix: 목록 페이지 수정 (코호트, 커스텀) 및 ID 표시 방식 변경

### DIFF
--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -313,7 +313,11 @@
                     {item.name}
                   </a>
                 </td>
-                <td class="py-3 px-4 text-sm text-gray-900">{item.description}</td>
+                <td class="py-3 px-4 text-sm text-gray-900">
+                  <div class="line-clamp-2 whitespace-pre-line">
+                    {item.description}
+                  </div>
+                </td>
                 <td class="py-3 px-4 text-sm text-gray-500">anonymous</td>
                 <td class="py-3 px-4 text-sm text-gray-500">{item.created_at}</td>
                 <td class="py-3 px-4 text-sm text-gray-500">{item.updated_at}</td>

--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -304,7 +304,7 @@
                     </div>
                   </div>
                 </td>
-                <td class="py-3 px-4 text-sm text-gray-500">{item.cohort_id}</td>
+                <td class="py-3 px-4 text-sm text-gray-500">{filteredData.length - ((currentPage - 1) * itemsPerPage + paginatedData.indexOf(item)) - 1 + 1}</td>
                 <td class="py-3 px-4">
                   <a 
                     href={`/cohort/${item.cohort_id}`} 

--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -271,18 +271,18 @@
       </div>
       
       <div class="overflow-x-auto">
-        <table class="min-w-full">
+        <table class="table-fixed w-full">
           <thead>
             <tr class="bg-gray-50 text-left">
-              <th class="w-10 py-3 px-4">
+              <th class="w-[5%] py-3 px-4">
                 <span class="sr-only">Select</span>
               </th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
+              <th class="w-[5%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">No.</th>
+              <th class="w-[25%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+              <th class="w-[35%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">

--- a/frontend/src/routes/cohort/+page.svelte
+++ b/frontend/src/routes/cohort/+page.svelte
@@ -277,12 +277,12 @@
               <th class="w-[5%] py-3 px-4">
                 <span class="sr-only">Select</span>
               </th>
-              <th class="w-[5%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">No.</th>
-              <th class="w-[25%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th class="w-[35%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
-              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
-              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Updated</th>
+              <th class="w-[5%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">No.</th>
+              <th class="w-[25%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Name</th>
+              <th class="w-[35%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Description</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Author</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Created</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Updated</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -319,8 +319,8 @@
                   </div>
                 </td>
                 <td class="py-3 px-4 text-sm text-gray-500">anonymous</td>
-                <td class="py-3 px-4 text-sm text-gray-500">{item.created_at}</td>
-                <td class="py-3 px-4 text-sm text-gray-500">{item.updated_at}</td>
+                <td class="py-3 px-4 text-sm text-gray-500 text-center">{item.created_at.slice(0,16)}</td>
+                <td class="py-3 px-4 text-sm text-gray-500 text-center">{item.updated_at.slice(0,16)}</td>
               </tr>
             {/each}
           </tbody>

--- a/frontend/src/routes/cohort/[cohortID]/+layout.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+layout.svelte
@@ -135,9 +135,6 @@
 		>
 			<div class="flex-1 min-w-0">
 				<div class="flex items-center gap-1">
-					<span class="text-[10px] font-medium text-gray-400 truncate">{cohortID}</span>
-				</div>
-				<div class="flex items-center gap-1">
 					<div class="truncate text-xs font-medium text-blue-600">{cohortInfo.name}</div>
 				</div>
 			</div>

--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -443,10 +443,6 @@
 			<!-- 상단 정보 -->
 			<div class="flex w-full items-center justify-between bg-gray-50 p-3">
 				<div class="flex items-center gap-4">
-					<div class="font-medium">
-						<span class="text-sm text-gray-400">ID </span>
-						<span class="text-black-500 text-sm">{cohortInfo.cohort_id}</span>
-					</div>
 					<div class="font-medium text-blue-600">{cohortInfo.name}</div>
 					<span class="rounded-full bg-blue-100 px-2 py-0.5 text-xs">
 						<span class="text-gray-600">Total patients:</span>
@@ -582,6 +578,10 @@
 			<div class="border-t p-4">
 				<div class="grid grid-cols-2 gap-4 text-sm">
 					<div>
+						<p class="text-gray-500">ID</p>
+						<p class="font-medium">{cohortInfo.cohort_id}</p>
+					</div>
+					<div>
 						<p class="text-gray-500">Author</p>
 						<p class="font-medium">anonymous</p>
 						<!-- <p class="font-medium">{cohortInfo.author}</p> -->
@@ -590,6 +590,10 @@
 					<div>
 						<p class="text-gray-500">Created at</p>
 						<p class="font-medium">{new Date(cohortInfo.created_at).toLocaleString()}</p>
+					</div>
+					<div>
+						<p class="text-gray-500">Updated at</p>
+						<p class="font-medium">{new Date(cohortInfo.updated_at).toLocaleString()}</p>
 					</div>
 					<div class="col-span-2">
 						<p class="text-gray-500">Description</p>

--- a/frontend/src/routes/cohort/[cohortID]/+page.svelte
+++ b/frontend/src/routes/cohort/[cohortID]/+page.svelte
@@ -666,10 +666,15 @@
 				<h2 class="text-xl font-semibold text-gray-800">
 					Cohort Feature Importance Analysis (SHAP)
 				</h2>
-				<p class="text-sm text-gray-600">
-					Enter the size of the comparison group to analyze the top features influencing this cohort
-					using the SHAP algorithm.
-				</p>
+				<div class="mb-4">
+					<p class="text-sm text-gray-600">
+						Enter the size of the comparison group to analyze the top features influencing this cohort
+						using the SHAP algorithm.
+					</p>
+					<p class="text-sm text-gray-600">
+						During model training, concept IDs used for patient cohort classification are excluded, and the model is built solely based on other clinical variables.
+					</p>
+				</div>
 
 				<div class="flex items-end space-x-4">
 					<div class="max-w-xs flex-grow">

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -544,7 +544,7 @@
                     </div>
                     <div>
                       <span class="text-gray-500">Description:</span>
-                      <span class="font-regular">{cohort.basicInfo.description}</span>
+                      <span class="font-regular break-words">{cohort.basicInfo.description}</span>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/routes/cohort/comparison/+page.svelte
+++ b/frontend/src/routes/cohort/comparison/+page.svelte
@@ -518,9 +518,6 @@
                   </svg>
                   <div class="flex-1 min-w-0">
                     <div class="flex items-center gap-1">
-                      <span class="text-[10px] font-medium text-gray-400 truncate">{cohort.basicInfo.cohort_id}</span>
-                    </div>
-                    <div class="flex items-center gap-1">
                     <div class="truncate text-xs font-medium text-blue-600">{cohort.basicInfo.name}</div>
                     </div>
                     <div class="flex items-center gap-1 mt-0.5">
@@ -532,6 +529,10 @@
               {#if expandedStates[index]}
                 <div class="p-2 border-t text-xs" transition:slide>
                   <div class="space-y-1">
+                    <div>
+                      <span class="text-gray-500">ID:</span>
+                      <span class="font-regular">{cohort.basicInfo.cohort_id}</span>
+                    </div>
                     <div>
                       <span class="text-gray-500">Author:</span>
                       <span class="font-regular">anonymous</span>

--- a/frontend/src/routes/custom-chart/+page.svelte
+++ b/frontend/src/routes/custom-chart/+page.svelte
@@ -200,17 +200,17 @@
       </div>
       
       <div class="overflow-x-auto">
-        <table class="min-w-full">
+        <table class="table-fixed min-w-full">
           <thead>
             <tr class="bg-gray-50 text-left">
-              <th class="w-10 py-3 px-4">
+              <th class="w-[5%] py-3 px-4">
                   <span class="sr-only">Select</span>
               </th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Author</th>
-              <th class="py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider">Created At</th>
+              <th class="w-[5%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">No.</th>
+              <th class="w-[30%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Name</th>
+              <th class="w-[40%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Description</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Author</th>
+              <th class="w-[10%] py-3 px-4 text-xs font-medium text-gray-500 uppercase tracking-wider text-center">Created At</th>
             </tr>
           </thead>
           <tbody class="bg-white divide-y divide-gray-200">
@@ -230,7 +230,7 @@
                     </div>
                   </div>
                 </td>
-                <td class="py-3 px-4 text-sm text-gray-500">{item.statistics_id}</td>
+                <td class="py-3 px-4 text-sm text-gray-500">{filteredData.length - ((currentPage - 1) * itemsPerPage + paginatedData.indexOf(item)) - 1 + 1}</td>
                 <td class="py-3 px-4">
                   <a 
                     href={`/custom-chart/${item.statistics_id}`} 
@@ -239,10 +239,14 @@
                     {item.name}
                   </a>
                 </td>
-                <td class="py-3 px-4 text-sm text-gray-900">{item.description}</td>
+                <td class="py-3 px-4 text-sm text-gray-900">
+                  <div class="line-clamp-2 whitespace-pre-line">
+                    {item.description}
+                  </div>
+                </td>
                 <!-- <td class="py-3 px-4 text-sm text-gray-500">{item.author}</td> -->
                 <td class="py-3 px-4 text-sm text-gray-500">anonymous</td>
-                <td class="py-3 px-4 text-sm text-gray-500">{item.created_at}</td>
+                <td class="py-3 px-4 text-sm text-gray-500 text-center">{item.created_at.slice(0,16)}</td>
               </tr>
             {/each}
           </tbody>

--- a/frontend/src/routes/custom-chart/[statisticsId]/+page.svelte
+++ b/frontend/src/routes/custom-chart/[statisticsId]/+page.svelte
@@ -168,9 +168,6 @@
 						>
 							<div class="min-w-0 flex-1">
 								<div class="flex items-center gap-1">
-									<span class="truncate text-[10px] font-medium text-gray-400">{id.cohort_id}</span>
-								</div>
-								<div class="flex items-center gap-1">
 									<div class="truncate text-xs font-medium text-blue-600">
 										{id.name}
 									</div>
@@ -186,10 +183,6 @@
 			<div class="flex w-[80%] flex-col">
 				<div class="flex items-center justify-between border-b bg-gray-50 p-3">
 					<div class="flex items-center gap-4">
-						<div class="font-medium">
-							<span class="text-sm text-gray-400">ID</span>
-							<span class="text-black-500 text-sm">{cumtomInfo.statistics_id}</span>
-						</div>
 						<div class="font-medium text-blue-600">{cumtomInfo.name}</div>
 					</div>
 					<div class="flex items-center gap-4">
@@ -237,6 +230,10 @@
 
 				<div class="overflow-y-auto p-4">
 					<div class="grid grid-cols-3 gap-4 text-sm">
+						<div>
+							<p class="text-gray-500">ID</p>
+							<p class="font-medium">{cumtomInfo.statistics_id}</p>
+						</div>
 						<div>
 							<p class="text-gray-500">Author</p>
 							<!-- <p class="font-medium">{cumtomInfo.author}</p> -->
@@ -314,10 +311,7 @@
 						</svg>
 						<div class="min-w-0 flex-1">
 							<div class="flex items-center gap-1">
-								<span class="truncate text-xs font-medium text-gray-400">{chart.id}</span>
-							</div>
-							<div class="flex items-center gap-1">
-								<div class="whitespace-normal break-words text-sm font-medium text-blue-600">
+								<div class="whitespace-normal break-words text-m font-medium text-blue-600">
 									{chart.name}
 								</div>
 							</div>
@@ -412,6 +406,10 @@
 
 						<div class="space-y-1">
 							<div>
+								<span class="text-gray-500">ID:</span>
+								<span class="font-regular">{chart.chart_id}</span>
+							</div>
+							<div>
 								<span class="text-gray-500">Author:</span>
 								<!-- <span class="font-regular">{chart.author}</span> -->
 								<span class="font-regular">anonymous</span>
@@ -421,12 +419,12 @@
 								<span class="font-regular">{chart.created_at}</span>
 							</div>
 							<div>
-								<span class="text-gray-500">Description:</span>
-								<span class="font-regular">{chart.description}</span>
-							</div>
-							<div>
 								<span class="text-gray-500">Chart Type:</span>
 								<span class="font-regular">{chart.type}</span>
+							</div>
+							<div>
+								<span class="text-gray-500">Description:</span>
+								<span class="font-regular">{chart.description}</span>
 							</div>
 						</div>
 						<!-- 차트 및 설명 영역 추가 -->


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#228 
## 📝 작업 내용
- 코호트 / 커스텀 목록 수정
    - [x]  표 열 고정하기 (커스텀 차트 목록도 똑같이 넣기, name길게)
    - [x]  시간 날짜 두줄로 나오게
    - [x]  name 길게
    - [x]  description truncate
    - [x]  id는 목록에서 빼기
    - [x]  인덱스 번호 넣기

## ✅ PR Checklist

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
